### PR TITLE
[KAI] 이슈작성

### DIFF
--- a/ios/issue-tracker-01/.swiftlint.yml
+++ b/ios/issue-tracker-01/.swiftlint.yml
@@ -6,6 +6,8 @@ disabled_rules:
 opt_in_rules:
     - empty_count
     - empty_string
-    
+file_length:
+  warning: 1000
+
 line_length: 300
 type_body_length: 500

--- a/ios/issue-tracker-01/issue-tracker-01.xcodeproj/project.pbxproj
+++ b/ios/issue-tracker-01/issue-tracker-01.xcodeproj/project.pbxproj
@@ -33,6 +33,9 @@
 		D61AACA32BFDE9E200D35399 /* MilestoneModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61AACA22BFDE9E200D35399 /* MilestoneModel.swift */; };
 		D61AACA62BFE0C6A00D35399 /* MilestoneEditorViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D61AACA52BFE0C6A00D35399 /* MilestoneEditorViewController.xib */; };
 		D61AACA72BFE0C6A00D35399 /* MilestoneEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61AACA42BFE0C6A00D35399 /* MilestoneEditorViewController.swift */; };
+		D61AACA92BFF38FB00D35399 /* OptionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61AACA82BFF38FB00D35399 /* OptionType.swift */; };
+		D61AACAC2BFF3A9400D35399 /* SelectedOptionCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D61AACAB2BFF3A9400D35399 /* SelectedOptionCell.xib */; };
+		D61AACAD2BFF3A9400D35399 /* SelectedOptionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61AACAA2BFF3A9400D35399 /* SelectedOptionCell.swift */; };
 		D6369F462BEA0F8F001BDAAB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6369F452BEA0F8F001BDAAB /* AppDelegate.swift */; };
 		D6369F482BEA0F8F001BDAAB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6369F472BEA0F8F001BDAAB /* SceneDelegate.swift */; };
 		D6369F4A2BEA0F8F001BDAAB /* LoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6369F492BEA0F8F001BDAAB /* LoginController.swift */; };
@@ -112,6 +115,9 @@
 		D61AACA22BFDE9E200D35399 /* MilestoneModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneModel.swift; sourceTree = "<group>"; };
 		D61AACA42BFE0C6A00D35399 /* MilestoneEditorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneEditorViewController.swift; sourceTree = "<group>"; };
 		D61AACA52BFE0C6A00D35399 /* MilestoneEditorViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MilestoneEditorViewController.xib; sourceTree = "<group>"; };
+		D61AACA82BFF38FB00D35399 /* OptionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionType.swift; sourceTree = "<group>"; };
+		D61AACAA2BFF3A9400D35399 /* SelectedOptionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedOptionCell.swift; sourceTree = "<group>"; };
+		D61AACAB2BFF3A9400D35399 /* SelectedOptionCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SelectedOptionCell.xib; sourceTree = "<group>"; };
 		D6369F422BEA0F8F001BDAAB /* issue-tracker-01.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "issue-tracker-01.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D6369F452BEA0F8F001BDAAB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D6369F472BEA0F8F001BDAAB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -250,6 +256,7 @@
 				D61179732BEC8FA900E7C267 /* Issue.swift */,
 				D61AAC962BFDA93100D35399 /* Label.swift */,
 				D61AAC982BFDAA4F00D35399 /* Milestone.swift */,
+				D61AACA82BFF38FB00D35399 /* OptionType.swift */,
 				D6A632162BF46ACC000E9C30 /* BaseModel.swift */,
 				D61AAC862BFAD62700D35399 /* IssueModel.swift */,
 				D61AAC882BFAF1A600D35399 /* LabelModel.swift */,
@@ -370,6 +377,8 @@
 				D642E2692BF6EFD000ACAE45 /* EditorOptionCell.xib */,
 				D642E26C2BF717BB00ACAE45 /* EditorOptionViewController.swift */,
 				D642E26D2BF717BB00ACAE45 /* EditorOptionViewController.xib */,
+				D61AACAA2BFF3A9400D35399 /* SelectedOptionCell.swift */,
+				D61AACAB2BFF3A9400D35399 /* SelectedOptionCell.xib */,
 			);
 			path = IssueEditor;
 			sourceTree = "<group>";
@@ -482,6 +491,7 @@
 				D61179502BEB792D00E7C267 /* .swiftlint.yml in Resources */,
 				D61AAC8C2BFB884500D35399 /* LabelEditorViewController.xib in Resources */,
 				D642E2732BF740A400ACAE45 /* LabelTableCell.xib in Resources */,
+				D61AACAC2BFF3A9400D35399 /* SelectedOptionCell.xib in Resources */,
 				D642E2662BF6182B00ACAE45 /* IssueEditorViewController.xib in Resources */,
 				D642E26F2BF717BB00ACAE45 /* EditorOptionViewController.xib in Resources */,
 				D6A6320B2BF34589000E9C30 /* IssueDetailViewController.xib in Resources */,
@@ -549,6 +559,8 @@
 				D6A631FB2BF1FE5A000E9C30 /* NetworkManager.swift in Sources */,
 				D642E26A2BF6EFD000ACAE45 /* EditorOptionCell.swift in Sources */,
 				D61AAC892BFAF1A600D35399 /* LabelModel.swift in Sources */,
+				D61AACAD2BFF3A9400D35399 /* SelectedOptionCell.swift in Sources */,
+				D61AACA92BFF38FB00D35399 /* OptionType.swift in Sources */,
 				D6A631FD2BF20BAC000E9C30 /* URLDefines.swift in Sources */,
 				D61AAC8F2BFC3AB400D35399 /* LabelEditorPaddingLabel.swift in Sources */,
 				D6A632032BF22217000E9C30 /* HTTPMethod.swift in Sources */,

--- a/ios/issue-tracker-01/issue-tracker-01.xcodeproj/project.pbxproj
+++ b/ios/issue-tracker-01/issue-tracker-01.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		D61AACA92BFF38FB00D35399 /* OptionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61AACA82BFF38FB00D35399 /* OptionType.swift */; };
 		D61AACAC2BFF3A9400D35399 /* SelectedOptionCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D61AACAB2BFF3A9400D35399 /* SelectedOptionCell.xib */; };
 		D61AACAD2BFF3A9400D35399 /* SelectedOptionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61AACAA2BFF3A9400D35399 /* SelectedOptionCell.swift */; };
+		D61AACB22C00497700D35399 /* EditorOptionLabelCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D61AACB12C00497700D35399 /* EditorOptionLabelCell.xib */; };
+		D61AACB32C00497700D35399 /* EditorOptionLabelCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D61AACB02C00497700D35399 /* EditorOptionLabelCell.swift */; };
 		D6369F462BEA0F8F001BDAAB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6369F452BEA0F8F001BDAAB /* AppDelegate.swift */; };
 		D6369F482BEA0F8F001BDAAB /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6369F472BEA0F8F001BDAAB /* SceneDelegate.swift */; };
 		D6369F4A2BEA0F8F001BDAAB /* LoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6369F492BEA0F8F001BDAAB /* LoginController.swift */; };
@@ -118,6 +120,8 @@
 		D61AACA82BFF38FB00D35399 /* OptionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionType.swift; sourceTree = "<group>"; };
 		D61AACAA2BFF3A9400D35399 /* SelectedOptionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedOptionCell.swift; sourceTree = "<group>"; };
 		D61AACAB2BFF3A9400D35399 /* SelectedOptionCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SelectedOptionCell.xib; sourceTree = "<group>"; };
+		D61AACB02C00497700D35399 /* EditorOptionLabelCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorOptionLabelCell.swift; sourceTree = "<group>"; };
+		D61AACB12C00497700D35399 /* EditorOptionLabelCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditorOptionLabelCell.xib; sourceTree = "<group>"; };
 		D6369F422BEA0F8F001BDAAB /* issue-tracker-01.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "issue-tracker-01.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D6369F452BEA0F8F001BDAAB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D6369F472BEA0F8F001BDAAB /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -375,6 +379,8 @@
 				D642E2652BF6182B00ACAE45 /* IssueEditorViewController.xib */,
 				D642E2682BF6EFD000ACAE45 /* EditorOptionCell.swift */,
 				D642E2692BF6EFD000ACAE45 /* EditorOptionCell.xib */,
+				D61AACB02C00497700D35399 /* EditorOptionLabelCell.swift */,
+				D61AACB12C00497700D35399 /* EditorOptionLabelCell.xib */,
 				D642E26C2BF717BB00ACAE45 /* EditorOptionViewController.swift */,
 				D642E26D2BF717BB00ACAE45 /* EditorOptionViewController.xib */,
 				D61AACAA2BFF3A9400D35399 /* SelectedOptionCell.swift */,
@@ -494,6 +500,7 @@
 				D61AACAC2BFF3A9400D35399 /* SelectedOptionCell.xib in Resources */,
 				D642E2662BF6182B00ACAE45 /* IssueEditorViewController.xib in Resources */,
 				D642E26F2BF717BB00ACAE45 /* EditorOptionViewController.xib in Resources */,
+				D61AACB22C00497700D35399 /* EditorOptionLabelCell.xib in Resources */,
 				D6A6320B2BF34589000E9C30 /* IssueDetailViewController.xib in Resources */,
 				D6369F4F2BEA0F90001BDAAB /* Assets.xcassets in Resources */,
 				D679EE472BEA355400A3FC61 /* Color.xcassets in Resources */,
@@ -558,6 +565,7 @@
 				D61AAC8D2BFB884500D35399 /* LabelEditorViewController.swift in Sources */,
 				D6A631FB2BF1FE5A000E9C30 /* NetworkManager.swift in Sources */,
 				D642E26A2BF6EFD000ACAE45 /* EditorOptionCell.swift in Sources */,
+				D61AACB32C00497700D35399 /* EditorOptionLabelCell.swift in Sources */,
 				D61AAC892BFAF1A600D35399 /* LabelModel.swift in Sources */,
 				D61AACAD2BFF3A9400D35399 /* SelectedOptionCell.swift in Sources */,
 				D61AACA92BFF38FB00D35399 /* OptionType.swift in Sources */,

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueDetail/IssueDetailCell.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueDetail/IssueDetailCell.swift
@@ -35,7 +35,7 @@ class IssueDetailCell: UITableViewCell {
         self.timeLabel.text = nil
         self.contentLabel.text = nil
         self.contentLabel.text = nil
-        self.authorLabel.text = nil
+        self.authorLabel.isHidden = true
     }
     
     private func configureFont() {

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueDetail/IssueDetailCell.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueDetail/IssueDetailCell.swift
@@ -26,12 +26,6 @@ class IssueDetailCell: UITableViewCell {
         
         configureFont()
     }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
-    }
     
     override func prepareForReuse() {
         super.prepareForReuse()

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueDetail/IssueDetailHeaderView.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueDetail/IssueDetailHeaderView.swift
@@ -38,7 +38,7 @@ class IssueDetailHeaderView: UITableViewHeaderFooterView {
         self.captionLabel.applyStyle(fontManager: FontManager(weight: .medium, size: .medium), textColor: .gray700)
     }
     
-    func setDetail(with issueDetail: IssueDetail) {
+    func setDetail(with issueDetail: IssueDetailResponse) {
         self.titleLabel.text = issueDetail.title
         self.idLabel.text = "#\(issueDetail.id)"
         

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionCell.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionCell.swift
@@ -92,7 +92,7 @@ extension EditorOptionCell: UICollectionViewDelegateFlowLayout {
         }
         
         let label = UILabel()
-        let padding: CGFloat = 20
+        let padding: CGFloat = 10
         label.applyStyle(fontManager: FontManager(weight: .bold, size: .medium), textColor: .gray50)
         label.text = option.displayText
         

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionCell.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionCell.swift
@@ -10,21 +10,35 @@ import UIKit
 class EditorOptionCell: UITableViewCell {
     
     static let identifier: String = "EditorOptionCell"
+    
+    private var options: [OptionType]? = [] {
+        didSet {
+            self.collectionView.reloadData()
+        }
+    }
 
     @IBOutlet weak var titleLabel: UILabel!
-    @IBOutlet weak var contentLabel: UILabel!
-
+    @IBOutlet weak var collectionView: UICollectionView!
+    
     override func awakeFromNib() {
         super.awakeFromNib()
         
-        self.contentLabel.text = nil
+        setupCollectionView()
     }
     
     override func prepareForReuse() {
         super.prepareForReuse()
         
         self.titleLabel.text = nil
-        self.contentLabel.text = nil
+    }
+    
+    private func setupCollectionView() {
+        self.collectionView.register(
+            UINib(nibName: "EditorOptionLabelCell", bundle: .main),
+            forCellWithReuseIdentifier: EditorOptionLabelCell.identifier
+        )
+        self.collectionView.dataSource = self
+        self.collectionView.delegate = self
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
@@ -44,5 +58,45 @@ class EditorOptionCell: UITableViewCell {
     
     func configureTitle(title: String) {
         self.titleLabel.text = title
+    }
+    
+    func configureOptions(options: [OptionType]?) {
+        self.options = options
+        self.collectionView.reloadData()
+    }
+}
+
+extension EditorOptionCell: UICollectionViewDataSource, UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return options?.count ?? 0
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: EditorOptionLabelCell.identifier, for: indexPath) as? EditorOptionLabelCell else {
+            return UICollectionViewCell()
+        }
+        
+        if let option = options?[indexPath.item] {
+            
+            cell.setLabel(with: option)
+        }
+        
+        return cell
+    }
+}
+
+extension EditorOptionCell: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        guard let option = options?[indexPath.item] else {
+            return CGSize(width: 0, height: 0)
+        }
+        
+        let label = UILabel()
+        let padding: CGFloat = 20
+        label.applyStyle(fontManager: FontManager(weight: .bold, size: .medium), textColor: .gray50)
+        label.text = option.displayText
+        
+        let width = label.intrinsicContentSize.width + padding
+        return CGSize(width: width, height: 24)
     }
 }

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionCell.xib
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionCell.xib
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,10 +17,10 @@
                 <rect key="frame" x="0.0" y="0.0" width="375" height="48"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="YOi-5e-FgV">
-                        <rect key="frame" x="16" y="8" width="326.33333333333331" height="32"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="YOi-5e-FgV">
+                        <rect key="frame" x="16" y="8" width="322.33333333333331" height="32"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="제목제목" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q8k-32-aQh">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" text="제목제목" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q8k-32-aQh">
                                 <rect key="frame" x="0.0" y="0.0" width="60" height="32"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="60" id="sWW-zW-skj"/>
@@ -29,17 +29,25 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="LabelLabelLabelLabelLabelLabelLabelLabelLabelLabelLabelLabel" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="k6w-p7-sWz">
-                                <rect key="frame" x="64" y="0.0" width="262.33333333333331" height="32"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="jmT-y6-GSc">
+                                <rect key="frame" x="68.000000000000014" y="0.0" width="254.33333333333337" height="32"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="aib-6M-Sfg">
+                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                            </collectionView>
                         </subviews>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="32" id="6Z5-sO-0G6"/>
+                        </constraints>
                     </stackView>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Gc1-dn-coW">
                         <rect key="frame" x="346.33333333333331" y="10.999999999999998" width="12.666666666666686" height="26.333333333333329"/>
                         <constraints>
+                            <constraint firstAttribute="height" constant="30" id="cew-C0-NDg"/>
                             <constraint firstAttribute="width" constant="12.67" id="kzU-iF-ole"/>
                         </constraints>
                     </imageView>
@@ -51,13 +59,13 @@
                     <constraint firstAttribute="bottom" secondItem="YOi-5e-FgV" secondAttribute="bottom" constant="8" id="f7e-8F-UIv"/>
                     <constraint firstItem="YOi-5e-FgV" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="qkN-xL-BCe"/>
                     <constraint firstItem="YOi-5e-FgV" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="r9C-Pb-beC"/>
-                    <constraint firstItem="Gc1-dn-coW" firstAttribute="leading" secondItem="YOi-5e-FgV" secondAttribute="trailing" constant="4" id="ueB-7c-K0f"/>
+                    <constraint firstItem="Gc1-dn-coW" firstAttribute="leading" secondItem="YOi-5e-FgV" secondAttribute="trailing" constant="8" id="ueB-7c-K0f"/>
                     <constraint firstItem="Gc1-dn-coW" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="9" id="v2G-9v-pSa"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
-                <outlet property="contentLabel" destination="k6w-p7-sWz" id="CJd-7d-dLd"/>
+                <outlet property="collectionView" destination="jmT-y6-GSc" id="S2Y-sj-Kwv"/>
                 <outlet property="titleLabel" destination="q8k-32-aQh" id="Uz1-W4-Luc"/>
             </connections>
             <point key="canvasLocation" x="101.5267175572519" y="7.746478873239437"/>

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionCell.xib
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionCell.xib
@@ -18,10 +18,10 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="YOi-5e-FgV">
-                        <rect key="frame" x="16" y="8" width="322.33333333333331" height="32"/>
+                        <rect key="frame" x="16" y="10" width="322.33333333333331" height="28"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" text="제목제목" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q8k-32-aQh">
-                                <rect key="frame" x="0.0" y="0.0" width="60" height="32"/>
+                                <rect key="frame" x="0.0" y="0.0" width="60" height="28"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="60" id="sWW-zW-skj"/>
                                 </constraints>
@@ -30,7 +30,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="jmT-y6-GSc">
-                                <rect key="frame" x="68.000000000000014" y="0.0" width="254.33333333333337" height="32"/>
+                                <rect key="frame" x="68.000000000000014" y="0.0" width="254.33333333333337" height="28"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="aib-6M-Sfg">
                                     <size key="itemSize" width="128" height="128"/>
@@ -41,7 +41,14 @@
                             </collectionView>
                         </subviews>
                         <constraints>
-                            <constraint firstAttribute="height" constant="32" id="6Z5-sO-0G6"/>
+                            <constraint firstAttribute="height" constant="28" id="6Z5-sO-0G6"/>
+                            <constraint firstAttribute="bottom" secondItem="jmT-y6-GSc" secondAttribute="bottom" id="7bQ-ET-pu6"/>
+                            <constraint firstItem="jmT-y6-GSc" firstAttribute="top" secondItem="YOi-5e-FgV" secondAttribute="top" id="BE5-Ra-1bk"/>
+                            <constraint firstItem="q8k-32-aQh" firstAttribute="top" secondItem="YOi-5e-FgV" secondAttribute="top" id="NX8-7j-COW"/>
+                            <constraint firstAttribute="bottom" secondItem="q8k-32-aQh" secondAttribute="bottom" id="WlC-6A-PI2"/>
+                            <constraint firstItem="q8k-32-aQh" firstAttribute="leading" secondItem="YOi-5e-FgV" secondAttribute="leading" id="jlS-mt-hqS"/>
+                            <constraint firstItem="jmT-y6-GSc" firstAttribute="leading" secondItem="q8k-32-aQh" secondAttribute="trailing" constant="8" symbolic="YES" id="k0V-9i-irG"/>
+                            <constraint firstAttribute="trailing" secondItem="jmT-y6-GSc" secondAttribute="trailing" id="mlT-ow-VDM"/>
                         </constraints>
                     </stackView>
                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="chevron.right" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Gc1-dn-coW">
@@ -55,12 +62,10 @@
                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="Gc1-dn-coW" secondAttribute="trailing" constant="16" id="3UE-E2-eqx"/>
-                    <constraint firstAttribute="bottom" secondItem="Gc1-dn-coW" secondAttribute="bottom" constant="9" id="5n6-bk-R1Z"/>
-                    <constraint firstAttribute="bottom" secondItem="YOi-5e-FgV" secondAttribute="bottom" constant="8" id="f7e-8F-UIv"/>
-                    <constraint firstItem="YOi-5e-FgV" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="qkN-xL-BCe"/>
+                    <constraint firstItem="YOi-5e-FgV" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="8Af-La-ZxT"/>
+                    <constraint firstItem="Gc1-dn-coW" firstAttribute="centerY" secondItem="YOi-5e-FgV" secondAttribute="centerY" id="Fl4-Ie-piq"/>
                     <constraint firstItem="YOi-5e-FgV" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="r9C-Pb-beC"/>
                     <constraint firstItem="Gc1-dn-coW" firstAttribute="leading" secondItem="YOi-5e-FgV" secondAttribute="trailing" constant="8" id="ueB-7c-K0f"/>
-                    <constraint firstItem="Gc1-dn-coW" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="9" id="v2G-9v-pSa"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionLabelCell.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionLabelCell.swift
@@ -1,0 +1,51 @@
+//
+//  EditorOptionLabelCell.swift
+//  issue-tracker-01
+//
+//  Created by 조호근 on 5/24/24.
+//
+
+import UIKit
+
+class EditorOptionLabelCell: UICollectionViewCell {
+    
+    static let identifier: String = "EditorOptionLabelCell"
+    
+    @IBOutlet weak var titleLabel: LabelEditorPaddingLabel!
+    @IBOutlet weak var containerView: UIView!
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        
+        self.containerView.layer.cornerRadius = 12
+        self.containerView.clipsToBounds = true
+        configureFont()
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        self.titleLabel.text = nil
+        self.titleLabel.textColor = .gray50
+        self.titleLabel.backgroundColor = .gray900
+    }
+    
+    private func configureFont() {
+        self.titleLabel.applyStyle(fontManager: FontManager(weight: .medium, size: .small), textColor: .gray50)
+        self.titleLabel.backgroundColor = .gray900
+    }
+    
+    func setLabel(with option: OptionType) {
+        switch option {
+        case .assignee(let assignee):
+            titleLabel.text = assignee.name
+        case .label(let label):
+            let color = UIColor(hex: label.color)
+            titleLabel.text = label.name
+            titleLabel.backgroundColor = color
+            titleLabel.textColor = color.isDarkColor ? .gray50 : .gray900
+        case .milestone(let milestone):
+            titleLabel.text = milestone.title
+        }
+    }
+}

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionLabelCell.xib
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionLabelCell.xib
@@ -31,7 +31,6 @@
                         <constraints>
                             <constraint firstItem="Ag2-Ab-nSC" firstAttribute="leading" secondItem="JBL-we-hAt" secondAttribute="leading" id="90N-W0-3si"/>
                             <constraint firstAttribute="bottom" secondItem="Ag2-Ab-nSC" secondAttribute="bottom" id="AU2-8r-ojh"/>
-                            <constraint firstAttribute="height" constant="30" id="akw-f3-Hn8"/>
                             <constraint firstItem="Ag2-Ab-nSC" firstAttribute="top" secondItem="JBL-we-hAt" secondAttribute="top" id="dzG-Oy-4s9"/>
                             <constraint firstAttribute="trailing" secondItem="Ag2-Ab-nSC" secondAttribute="trailing" id="pkS-gD-aCe"/>
                         </constraints>

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionLabelCell.xib
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionLabelCell.xib
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="gTV-IL-0wX" customClass="EditorOptionLabelCell" customModule="issue_tracker_01" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="91" height="32"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                <rect key="frame" x="0.0" y="0.0" width="91" height="32"/>
+                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JBL-we-hAt">
+                        <rect key="frame" x="0.0" y="0.0" width="91" height="32"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ag2-Ab-nSC" customClass="LabelEditorPaddingLabel" customModule="issue_tracker_01" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="91" height="32"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Ag2-Ab-nSC" firstAttribute="leading" secondItem="JBL-we-hAt" secondAttribute="leading" id="90N-W0-3si"/>
+                            <constraint firstAttribute="bottom" secondItem="Ag2-Ab-nSC" secondAttribute="bottom" id="AU2-8r-ojh"/>
+                            <constraint firstAttribute="height" constant="30" id="akw-f3-Hn8"/>
+                            <constraint firstItem="Ag2-Ab-nSC" firstAttribute="top" secondItem="JBL-we-hAt" secondAttribute="top" id="dzG-Oy-4s9"/>
+                            <constraint firstAttribute="trailing" secondItem="Ag2-Ab-nSC" secondAttribute="trailing" id="pkS-gD-aCe"/>
+                        </constraints>
+                    </view>
+                </subviews>
+            </view>
+            <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
+            <constraints>
+                <constraint firstItem="JBL-we-hAt" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="bfy-5N-ebE"/>
+                <constraint firstAttribute="trailing" secondItem="JBL-we-hAt" secondAttribute="trailing" id="td3-HN-VVd"/>
+                <constraint firstAttribute="bottom" secondItem="JBL-we-hAt" secondAttribute="bottom" id="tuq-ax-qms"/>
+                <constraint firstItem="JBL-we-hAt" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="vwR-Gm-2FU"/>
+            </constraints>
+            <size key="customSize" width="139" height="62"/>
+            <connections>
+                <outlet property="containerView" destination="JBL-we-hAt" id="4i6-x0-x1X"/>
+                <outlet property="titleLabel" destination="Ag2-Ab-nSC" id="J91-N0-Q3k"/>
+            </connections>
+            <point key="canvasLocation" x="70.992366412213741" y="-8.4507042253521139"/>
+        </collectionViewCell>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionViewController.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionViewController.swift
@@ -14,11 +14,28 @@ class EditorOptionViewController: UIViewController {
     @IBOutlet weak var tableView: UITableView!
     
     var sectionTitle: String?
+    var issueModel: IssueModel!
+    var options: [OptionType] = [] {
+        didSet {
+            unselectedOptions = options
+            self.tableView.reloadData()
+        }
+    }
+    
+    private var unselectedOptions: [OptionType] = []
+    private var selectedOptions: [OptionType] = []
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
         configureNavigationBar()
+        setupTableView()
+    }
+    
+    private func setupTableView() {
+        tableView.register(UINib(nibName: SelectedOptionCell.identifier, bundle: .main), forCellReuseIdentifier: SelectedOptionCell.identifier)
+        tableView.dataSource = self
+        tableView.delegate = self
     }
     
     private func configureNavigationBar() {
@@ -47,5 +64,60 @@ class EditorOptionViewController: UIViewController {
     
     @objc private func saveBtnTapped() {
         
+    }
+}
+
+extension EditorOptionViewController: UITableViewDataSource, UITableViewDelegate {
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 2
+    }
+    
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return section == 0 ? "선택됨" : "선택하지 않음"
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return section == 0 ? selectedOptions.count : unselectedOptions.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: SelectedOptionCell.identifier, for: indexPath) as? SelectedOptionCell else {
+            return UITableViewCell()
+        }
+        
+        let option: OptionType
+        let isSelected: Bool
+        switch indexPath.section {
+        case 0:
+            option = selectedOptions[indexPath.row]
+            isSelected = true
+        case 1:
+            option = unselectedOptions[indexPath.row]
+            isSelected = false
+        default:
+            return UITableViewCell()
+        }
+        
+        cell.configureCell(with: option, isSelected: isSelected)
+        
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        
+        switch indexPath.section {
+        case 0:
+            let option = selectedOptions.remove(at: indexPath.row)
+            unselectedOptions.append(option)
+        case 1:
+            let option = unselectedOptions.remove(at: indexPath.row)
+            selectedOptions.append(option)
+        default:
+            return
+        }
+        
+        tableView.reloadData()
     }
 }

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionViewController.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/EditorOptionViewController.swift
@@ -58,7 +58,6 @@ class EditorOptionViewController: UIViewController {
         tableView.register(UINib(nibName: SelectedOptionCell.identifier, bundle: .main), forCellReuseIdentifier: SelectedOptionCell.identifier)
         tableView.dataSource = self
         tableView.delegate = self
-        tableView.rowHeight = 44
     }
     
     private func configureNavigationBar() {
@@ -186,5 +185,9 @@ extension EditorOptionViewController: UITableViewDataSource, UITableViewDelegate
         
         selectedMilestone = newMilestone
         selectedOptions = [OptionType.milestone(newMilestone)]
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 44.0
     }
 }

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/IssueEditorViewController.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/IssueEditorViewController.swift
@@ -15,6 +15,8 @@ class IssueEditorViewController: UIViewController {
     @IBOutlet weak var optionInfoLabel: UILabel!
     @IBOutlet weak var tableView: UITableView!
     
+    var issueModel: IssueModel!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -109,11 +111,37 @@ extension IssueEditorViewController: UITableViewDataSource, UITableViewDelegate 
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let editorOptionVC = EditorOptionViewController(nibName: EditorOptionViewController.identifier, bundle: nil)
+        editorOptionVC.issueModel = self.issueModel
         
         switch indexPath.row {
-        case 0: editorOptionVC.sectionTitle = "담당자"
+        case 0: 
+            editorOptionVC.sectionTitle = "담당자"
+            issueModel.fetchAssignees { result in
+                switch result {
+                case .success(let assignees):
+                    editorOptionVC.options = assignees.map { OptionType.assignee($0) }
+                case .failure(let error):
+                    print("[ fetch assignees 실패 ]: \(error) ")
+                }
+            }
         case 1: editorOptionVC.sectionTitle = "레이블"
+            issueModel.fetchLabels { result in
+                switch result {
+                case .success(let labels):
+                    editorOptionVC.options = labels.map { OptionType.label($0) }
+                case .failure(let error):
+                    print("[ fetch labels 실패 ]: \(error) ")
+                }
+            }
         case 2: editorOptionVC.sectionTitle = "마일스톤"
+            issueModel.fetchMilestones { result in
+                switch result {
+                case .success(let milestones):
+                    editorOptionVC.options = milestones.map { OptionType.milestone($0) }
+                case .failure(let error):
+                    print("[ fetch milestones 실패 ]: \(error) ")
+                }
+            }
         default: return
         }
         

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/IssueEditorViewController.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/IssueEditorViewController.swift
@@ -202,7 +202,7 @@ extension IssueEditorViewController: UITableViewDataSource, UITableViewDelegate 
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 48
+        return 50
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/IssueEditorViewController.xib
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/IssueEditorViewController.xib
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -41,7 +41,7 @@
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="9kw-me-K5k">
+                                        <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="제목을 입력하세요" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="9kw-me-K5k">
                                             <rect key="frame" x="110" y="6" width="267" height="32"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <textInputTraits key="textInputTraits"/>
@@ -64,7 +64,6 @@
                                         <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="clM-0x-rPg">
                                             <rect key="frame" x="16" y="6" width="361" height="503"/>
                                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                            <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                             <color key="textColor" systemColor="labelColor"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/IssueEditorViewController.xib
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/IssueEditorViewController.xib
@@ -11,8 +11,10 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="IssueEditorViewController" customModule="issue_tracker_01" customModuleProvider="target">
             <connections>
+                <outlet property="descriptionField" destination="clM-0x-rPg" id="E0g-n1-p9Y"/>
                 <outlet property="optionInfoLabel" destination="nIi-k9-9Vs" id="rCe-BM-hXB"/>
                 <outlet property="tableView" destination="Orz-Tm-q2P" id="vfz-Rq-yA7"/>
+                <outlet property="titleField" destination="9kw-me-K5k" id="574-75-Hdt"/>
                 <outlet property="titleLabel" destination="chA-ZK-nK6" id="2uZ-qt-faG"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/SelectedOptionCell.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/SelectedOptionCell.swift
@@ -1,0 +1,55 @@
+//
+//  SelectedOptionCell.swift
+//  issue-tracker-01
+//
+//  Created by 조호근 on 5/23/24.
+//
+
+import UIKit
+
+class SelectedOptionCell: UITableViewCell {
+
+    static let identifier: String = "SelectedOptionCell"
+    
+    @IBOutlet weak var titleLabel: LabelEditorPaddingLabel!
+    @IBOutlet weak var circleImage: UIImageView!
+    
+    var isOptionSelected: Bool = false {
+        didSet {
+            updateCircleImage()
+        }
+    }
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        
+        titleLabel.layer.cornerRadius = 12
+        titleLabel.clipsToBounds = true
+        configureFont()
+        titleLabel.backgroundColor = .gray900
+    }
+
+    private func configureFont() {
+        self.titleLabel.applyStyle(fontManager: FontManager(weight: .medium, size: .small), textColor: .gray50)
+    }
+    
+    private func updateCircleImage() {
+        circleImage.image = isOptionSelected ? UIImage(systemName: "multiply.circle.fill")?.withTintColor(.gray600, renderingMode: .alwaysOriginal) : UIImage(systemName: "plus.circle")
+    }
+    
+    func configureCell(with option: OptionType, isSelected: Bool) {
+        switch option {
+        case .assignee(let assignee):
+            titleLabel.text = assignee.name
+        case .label(let label):
+            let color = UIColor(hex: label.color)
+            titleLabel.text = label.name
+            titleLabel.backgroundColor = color
+            titleLabel.textColor = color.isDarkColor ? .gray50 : .gray900
+        case .milestone(let milestone):
+            titleLabel.text = milestone.title
+        }
+        
+        isOptionSelected = isSelected
+    }
+}

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/SelectedOptionCell.xib
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/SelectedOptionCell.xib
@@ -10,38 +10,36 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="SelectedOptionCell" customModule="issue_tracker_01" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="47" id="KGk-i7-Jjw" customClass="SelectedOptionCell" customModule="issue_tracker_01" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="319" height="47"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <rect key="frame" x="0.0" y="0.0" width="319" height="47"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PjJ-L9-eqt" customClass="LabelEditorPaddingLabel" customModule="issue_tracker_01" customModuleProvider="target">
-                        <rect key="frame" x="16.000000000000004" y="10" width="41.333333333333343" height="24"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="24" id="iBJ-SA-Pdx"/>
-                        </constraints>
+                        <rect key="frame" x="16.000000000000004" y="10" width="41.333333333333343" height="27"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="8Hu-CP-HAJ">
-                        <rect key="frame" x="280" y="10" width="24" height="24"/>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="8Hu-CP-HAJ">
+                        <rect key="frame" x="279" y="11.666666666666664" width="24" height="24"/>
                         <color key="tintColor" name="myBlue"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="24" id="9Ro-86-eyd"/>
-                            <constraint firstAttribute="width" constant="24" id="b4s-HE-cMQ"/>
+                            <constraint firstAttribute="height" constant="24" id="I10-Iu-2Bt"/>
+                            <constraint firstAttribute="width" constant="24" id="lUi-0z-7f5"/>
                         </constraints>
                     </imageView>
                 </subviews>
                 <color key="tintColor" red="0.57504190721428572" green="0.5974168952170068" blue="0.26799000850340138" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 <constraints>
-                    <constraint firstItem="8Hu-CP-HAJ" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="2G9-2g-BLo"/>
                     <constraint firstItem="PjJ-L9-eqt" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="6PP-7a-dUq"/>
-                    <constraint firstItem="PjJ-L9-eqt" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="GK6-FP-LUi"/>
-                    <constraint firstAttribute="trailing" secondItem="8Hu-CP-HAJ" secondAttribute="trailing" constant="16" id="gaO-82-D6A"/>
-                    <constraint firstItem="8Hu-CP-HAJ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="PjJ-L9-eqt" secondAttribute="trailing" constant="16" id="vQt-Vo-bAe"/>
+                    <constraint firstAttribute="bottom" secondItem="PjJ-L9-eqt" secondAttribute="bottom" constant="10" id="LHP-az-oLb"/>
+                    <constraint firstAttribute="trailing" secondItem="8Hu-CP-HAJ" secondAttribute="trailing" constant="16" id="aiL-C2-9Q0"/>
+                    <constraint firstItem="8Hu-CP-HAJ" firstAttribute="centerY" secondItem="PjJ-L9-eqt" secondAttribute="centerY" id="cwQ-Gb-fUU"/>
+                    <constraint firstItem="PjJ-L9-eqt" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="dvO-01-uf5"/>
+                    <constraint firstItem="8Hu-CP-HAJ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="PjJ-L9-eqt" secondAttribute="trailing" constant="16" id="mEt-G0-do7"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
@@ -49,7 +47,7 @@
                 <outlet property="circleImage" destination="8Hu-CP-HAJ" id="ef4-fB-eZg"/>
                 <outlet property="titleLabel" destination="PjJ-L9-eqt" id="Umg-hK-Xlf"/>
             </connections>
-            <point key="canvasLocation" x="-12.213740458015266" y="-12.67605633802817"/>
+            <point key="canvasLocation" x="-12.977099236641221" y="-11.619718309859156"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/SelectedOptionCell.xib
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueEditor/SelectedOptionCell.xib
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="SelectedOptionCell" customModule="issue_tracker_01" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PjJ-L9-eqt" customClass="LabelEditorPaddingLabel" customModule="issue_tracker_01" customModuleProvider="target">
+                        <rect key="frame" x="16.000000000000004" y="10" width="41.333333333333343" height="24"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="24" id="iBJ-SA-Pdx"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="8Hu-CP-HAJ">
+                        <rect key="frame" x="280" y="10" width="24" height="24"/>
+                        <color key="tintColor" name="myBlue"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="24" id="9Ro-86-eyd"/>
+                            <constraint firstAttribute="width" constant="24" id="b4s-HE-cMQ"/>
+                        </constraints>
+                    </imageView>
+                </subviews>
+                <color key="tintColor" red="0.57504190721428572" green="0.5974168952170068" blue="0.26799000850340138" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                <constraints>
+                    <constraint firstItem="8Hu-CP-HAJ" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="2G9-2g-BLo"/>
+                    <constraint firstItem="PjJ-L9-eqt" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="6PP-7a-dUq"/>
+                    <constraint firstItem="PjJ-L9-eqt" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="GK6-FP-LUi"/>
+                    <constraint firstAttribute="trailing" secondItem="8Hu-CP-HAJ" secondAttribute="trailing" constant="16" id="gaO-82-D6A"/>
+                    <constraint firstItem="8Hu-CP-HAJ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="PjJ-L9-eqt" secondAttribute="trailing" constant="16" id="vQt-Vo-bAe"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="circleImage" destination="8Hu-CP-HAJ" id="ef4-fB-eZg"/>
+                <outlet property="titleLabel" destination="PjJ-L9-eqt" id="Umg-hK-Xlf"/>
+            </connections>
+            <point key="canvasLocation" x="-12.213740458015266" y="-12.67605633802817"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <namedColor name="myBlue">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueListController.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueListController.swift
@@ -57,6 +57,8 @@ class IssueListController: UIViewController {
     
     @objc private func plusButtonTapped() {
         let issueEditorVC = IssueEditorViewController(nibName: IssueEditorViewController.identifier, bundle: nil)
+        issueEditorVC.issueModel = self.issueModel
+        
         navigationController?.pushViewController(issueEditorVC, animated: true)
     }
 }
@@ -130,6 +132,7 @@ extension IssueListController: UITableViewDataSource, UITableViewDelegate {
     private func showIssueDetail(issueId: Int) {
         let issueDetailVC = IssueDetailViewController(nibName: IssueDetailViewController.identifier, bundle: nil)
         issueDetailVC.issueId = issueId
+        issueDetailVC.issueModel = self.issueModel
         issueDetailVC.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(issueDetailVC, animated: true)
     }

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueListController.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueListController.swift
@@ -20,6 +20,19 @@ class IssueListController: UIViewController {
         
         fetchIssues()
         setupPlusButton()
+        registerForNotifications()
+    }
+    
+    private func registerForNotifications() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(handleIssueUpdated),
+                                               name: IssueModel.Notifications.issueCreated,
+                                               object: nil
+        )
+    }
+    
+    @objc private func handleIssueUpdated(notification: Notification) {
+        self.tableView.reloadData()
     }
     
     private func setupTableView() {

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/IssueTableCell.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/IssueTableCell.swift
@@ -72,11 +72,6 @@ class IssueTableCell: UITableViewCell {
         self.lables = data
         self.collectionView.reloadData()
     }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-    }
 }
 
 extension IssueTableCell: UICollectionViewDataSource, UICollectionViewDelegate {

--- a/ios/issue-tracker-01/issue-tracker-01/Issue/LabelCell.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Issue/LabelCell.swift
@@ -30,12 +30,15 @@ class LabelCell: UICollectionViewCell {
     }
 
     private func configureFont() {
-        self.titleLabel.applyStyle(fontManager: FontManager(weight: .bold, size: .medium), textColor: .gray50)
+        self.titleLabel.applyStyle(fontManager: FontManager(weight: .medium, size: .small), textColor: .gray50)
         self.titleLabel.backgroundColor = .clear
     }
     
     func setLabel(_ data: LabelResponse) {
+        let color = UIColor(hex: data.color)
+        
         self.titleLabel.text = data.name
-        self.titleLabel.backgroundColor = UIColor(hex: data.color)
+        self.titleLabel.backgroundColor = color
+        self.titleLabel.textColor = color.isDarkColor ? .gray50 : .gray900
     }
 }

--- a/ios/issue-tracker-01/issue-tracker-01/Label/LabelListController.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Label/LabelListController.swift
@@ -91,7 +91,7 @@ extension LabelListController: UITableViewDataSource, UITableViewDelegate {
         let deleteAction = createSwipeAction(title: "삭제",
                                              color: .myRed,
                                              image: UIImage(systemName: "trash.fill"),
-                                             style: .destructive) { _, _, completionHandler in
+                                             style: .normal) { _, _, completionHandler in
             guard let label = self.labelModel.item(at: indexPath.row) else {
                 completionHandler(false)
                 return
@@ -99,7 +99,7 @@ extension LabelListController: UITableViewDataSource, UITableViewDelegate {
             
             self.labelModel.deleteLabel(at: indexPath.row) { success in
                 if success {
-                    tableView.deleteRows(at: [indexPath], with: .automatic)
+                    tableView.deleteRows(at: [indexPath], with: .bottom)
                     print("\(label.id) 삭제")
                 }
                 completionHandler(success)

--- a/ios/issue-tracker-01/issue-tracker-01/Label/LabelListController.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Label/LabelListController.swift
@@ -83,6 +83,10 @@ extension LabelListController: UITableViewDataSource, UITableViewDelegate {
         return cell
     }
     
+    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        return nil
+    }
+    
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let deleteAction = createSwipeAction(title: "삭제",
                                              color: .myRed,

--- a/ios/issue-tracker-01/issue-tracker-01/Milestone/MilestoneEditorViewController.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Milestone/MilestoneEditorViewController.swift
@@ -52,24 +52,36 @@ class MilestoneEditorViewController: UIViewController {
         deadlineField.addTarget(self, action: #selector(deadlineFieldDidChange(_:)), for: .editingChanged)
     }
     
+    @objc private func textFieldDidChange(_ textField: UITextField) {
+        let isTitleValid = !(titleField.text?.isEmpty ?? true)
+                
+        navigationItem.rightBarButtonItem?.isEnabled = isTitleValid
+    }
+    
     @objc private func deadlineFieldDidChange(_ textField: UITextField) {
-        if let deadlineText = textField.text, isVaildData(dateString: deadlineText) {
+        if let deadlineText = textField.text, isVaildDate(dateString: deadlineText) {
             deadlineLabel.textColor = .gray800
+            navigationItem.rightBarButtonItem?.isEnabled = isAllFieldsValid()
         } else {
             deadlineLabel.textColor = .red
+            navigationItem.rightBarButtonItem?.isEnabled = false
         }
     }
     
-    private func isVaildData(dateString: String) -> Bool {
+    private func isAllFieldsValid() -> Bool {
+        guard let titleText = titleField.text,
+              let deadlineText = deadlineField.text,
+              !titleText.isEmpty,
+              isVaildDate(dateString: deadlineText) else {
+            return false
+        }
+        return true
+    }
+    
+    private func isVaildDate(dateString: String) -> Bool {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy.MM.dd"
         return dateFormatter.date(from: dateString) != nil
-    }
-    
-    @objc private func textFieldDidChange(_ textField: UITextField) {
-        let isTitleValid = !(titleField.text?.isEmpty ?? true)
-        
-        navigationItem.rightBarButtonItem?.isEnabled = isTitleValid
     }
 
     private func configureFont() {

--- a/ios/issue-tracker-01/issue-tracker-01/Milestone/MilestoneListController.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Milestone/MilestoneListController.swift
@@ -89,6 +89,10 @@ extension MilestoneListController: UITableViewDataSource, UITableViewDelegate {
         return cell
     }
     
+    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
+        return nil
+    }
+    
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         let deleteAction = createSwipeAction(title: "삭제",
                                              color: .myRed,

--- a/ios/issue-tracker-01/issue-tracker-01/Milestone/MilestoneListController.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Milestone/MilestoneListController.swift
@@ -42,7 +42,7 @@ class MilestoneListController: UIViewController {
         
         milestoneModel.milestoneDeleted
             .sink { [weak self] index in
-                self?.tableView.deleteRows(at: [IndexPath(row: index, section: 0)], with: .automatic)
+                self?.tableView.deleteRows(at: [IndexPath(row: index, section: 0)], with: .bottom)
             }
             .store(in: &cancelMilestones)
     }

--- a/ios/issue-tracker-01/issue-tracker-01/Milestone/MilestoneTableCell.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Milestone/MilestoneTableCell.swift
@@ -23,12 +23,6 @@ class MilestoneTableCell: UITableViewCell {
         
         configureFont()
     }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
-    }
     
     private func configureFont() {
         self.nameLabel.applyStyle(fontManager: FontManager(weight: .semibold, size: .large), textColor: .gray900)

--- a/ios/issue-tracker-01/issue-tracker-01/Models/BaseModel.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Models/BaseModel.swift
@@ -11,7 +11,7 @@ protocol ItemManaging: AnyObject {
     associatedtype T
     
     var count: Int { get }
-    func updateItems(with newItems: [T])
+    func updateItems(with newItems: [T]?)
     func item(at index: Int) -> T?
     func removeItem(at index: Int)
     func appendItem(_ item: T)
@@ -25,8 +25,10 @@ class BaseModel<T>: ItemManaging {
         return items.count
     }
     
-    func updateItems(with newItems: [T]) {
-        self.items = newItems
+    func updateItems(with newItems: [T]?) {
+        if let newItems = newItems {
+            self.items = newItems
+        }
     }
     
     func item(at index: Int) -> T? {

--- a/ios/issue-tracker-01/issue-tracker-01/Models/Issue.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Models/Issue.swift
@@ -15,7 +15,7 @@ struct Issue: Codable {
     let milestone: CurrentMilestone?
 }
 
-struct IssueDetail: Codable {
+struct IssueDetailResponse: Codable {
     let id: Int
     let title: String
     let author: String
@@ -35,4 +35,12 @@ struct Comment: Codable {
     let fileUrls: [String]
     let likedCount: Int
     let lastModifiedAt: String
+}
+
+struct IssueCreationRequest: Codable {
+    let title: String
+    let comment: String
+    let assigneeIds: [String]
+    let labelIds: [Int]
+    let milestoneId: Int?
 }

--- a/ios/issue-tracker-01/issue-tracker-01/Models/IssueModel.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Models/IssueModel.swift
@@ -6,8 +6,24 @@
 //
 
 import Foundation
+import Combine
 
 class IssueModel: BaseModel<Issue> {
+    @Published private(set) var issueDetail: IssueDetailResponse?
+    var issueDetailPublisher: Published<IssueDetailResponse?>.Publisher { $issueDetail }
+    
+    var comment: [Comment]? {
+        return self.issueDetail?.comments
+    }
+    
+    func fetchIssueDetail(issueId: Int) {
+        NetworkManager.shared.fetchIssueDetail(issueId: issueId) { [weak self] issueDetail in
+            DispatchQueue.main.async {
+                self?.issueDetail = issueDetail
+            }
+        }
+    }
+    
     func fetchIssues(completion: @escaping () -> Void) {
         NetworkManager.shared.fetchIssues { [weak self] issues in
             DispatchQueue.main.async {
@@ -15,6 +31,18 @@ class IssueModel: BaseModel<Issue> {
                 completion()
             }
         }
+    }
+    
+    func fetchAssignees(completion: @escaping (Result<[AssigneeResponse], Error>) -> Void) {
+        NetworkManager.shared.fetchSelectedOption(from: .assignee, decodingType: [AssigneeResponse].self, completion: completion)
+    }
+    
+    func fetchLabels(completion: @escaping (Result<[LabelResponse], Error>) -> Void) {
+        NetworkManager.shared.fetchSelectedOption(from: .label, decodingType: [LabelResponse].self, completion: completion)
+    }
+    
+    func fetchMilestones(completion: @escaping (Result<[CurrentMilestone], Error>) -> Void) {
+        NetworkManager.shared.fetchSelectedOption(from: .milestone, decodingType: [CurrentMilestone].self, completion: completion)
     }
     
     func deleteIssue(at index: Int, completion: @escaping (Bool) -> Void) {

--- a/ios/issue-tracker-01/issue-tracker-01/Models/IssueModel.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Models/IssueModel.swift
@@ -9,6 +9,11 @@ import Foundation
 import Combine
 
 class IssueModel: BaseModel<Issue> {
+    
+    enum Notifications {
+        static let issueCreated = Notification.Name("issueCreated")
+    }
+    
     @Published private(set) var issueDetail: IssueDetailResponse?
     var issueDetailPublisher: Published<IssueDetailResponse?>.Publisher { $issueDetail }
     
@@ -74,6 +79,19 @@ class IssueModel: BaseModel<Issue> {
                 self?.removeItem(at: index)
                 completion(true)
             } else {
+                completion(false)
+            }
+        }
+    }
+    
+    func createIsuue(issueRequest: IssueCreationRequest, completion: @escaping (Bool) -> Void) {
+        NetworkManager.shared.createIssue(issueRequest: issueRequest) { result in
+            switch result {
+            case .success(let issue):
+                self.appendItem(issue)
+                NotificationCenter.default.post(name: Self.Notifications.issueCreated, object: self)
+                completion(true)
+            case .failure(let error):
                 completion(false)
             }
         }

--- a/ios/issue-tracker-01/issue-tracker-01/Models/Label.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Models/Label.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct LabelResponse: Codable {
+struct LabelResponse: Codable, Hashable {
     let id: Int
     let name: String
     let description: String

--- a/ios/issue-tracker-01/issue-tracker-01/Models/Milestone.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Models/Milestone.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct CurrentMilestone: Codable {
+struct CurrentMilestone: Codable, Hashable {
     let id: Int
     let title: String
 }

--- a/ios/issue-tracker-01/issue-tracker-01/Models/OptionType.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Models/OptionType.swift
@@ -1,0 +1,36 @@
+//
+//  OptionType.swift
+//  issue-tracker-01
+//
+//  Created by 조호근 on 5/23/24.
+//
+
+import Foundation
+
+struct AssigneeResponse: Codable {
+    let id: String
+    let name: String
+}
+
+enum OptionType {
+    case assignee(AssigneeResponse)
+    case label(LabelResponse)
+    case milestone(CurrentMilestone)
+}
+
+enum APIEndpoint {
+    case assignee
+    case label
+    case milestone
+    
+    var urlString: String {
+        switch self {
+        case .assignee:
+            return "/assignee"
+        case .label:
+            return "/label"
+        case .milestone:
+            return "/milestone"
+        }
+    }
+}

--- a/ios/issue-tracker-01/issue-tracker-01/Models/OptionType.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Models/OptionType.swift
@@ -7,15 +7,47 @@
 
 import Foundation
 
-struct AssigneeResponse: Codable {
+struct AssigneeResponse: Codable, Hashable {
     let id: String
     let name: String
 }
 
-enum OptionType {
+enum OptionType: Hashable {
+    
     case assignee(AssigneeResponse)
     case label(LabelResponse)
     case milestone(CurrentMilestone)
+    
+    var displayText: String {
+        switch self {
+        case .assignee(let assignee):
+            return assignee.name
+        case .label(let label):
+            return label.name
+        case .milestone(let milestone):
+            return milestone.title
+        }
+    }
+    
+    func isMilestone(withId id: Int) -> Bool {
+        if case .milestone(let currentMilestone) = self {
+            return currentMilestone.id == id
+        }
+        return false
+    }
+    
+    static func == (lhs: OptionType, rhs: OptionType) -> Bool {
+        switch (lhs, rhs) {
+        case (.assignee(let lhsAssignee), .assignee(let rhsAssignee)):
+            return lhsAssignee.id == rhsAssignee.id
+        case (.label(let lhsLabel), .label(let rhsLabel)):
+            return lhsLabel.id == rhsLabel.id
+        case (.milestone(let lhsMilestone), .milestone(let rhsMilestone)):
+            return lhsMilestone.id == rhsMilestone.id
+        default:
+            return false
+        }
+    }
 }
 
 enum APIEndpoint {

--- a/ios/issue-tracker-01/issue-tracker-01/Network/NetworkManager.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/Network/NetworkManager.swift
@@ -9,6 +9,12 @@ import Foundation
 import os
 
 class NetworkManager {
+    
+    enum NetworkError: Error {
+        case invalidURL
+        case unknown
+    }
+    
     static let shared = NetworkManager()
     private let httpManager: HTTPManagerProtocol
     
@@ -16,6 +22,29 @@ class NetworkManager {
     
     init(httpManager: HTTPManagerProtocol = HTTPManager.shared) {
         self.httpManager = httpManager
+    }
+    
+    func fetchSelectedOption<T: Codable>(from endpoint: APIEndpoint, decodingType: T.Type, completion: @escaping (Result<T, Error>) -> Void) {
+        guard let url = URL(string: URLDefines.select + endpoint.urlString) else {
+            completion(.failure(NetworkError.invalidURL))
+            return
+        }
+        let request = URLRequest(url: url)
+        
+        httpManager.sendRequest(request) { data, _, error in
+            guard let data = data, error == nil else {
+                completion(.failure(error ?? NetworkError.unknown))
+                return
+            }
+            
+            do {
+                let decodedData = try JSONDecoder().decode(T.self, from: data)
+                self.prettyPrintJSON(decodedData)
+                completion(.success(decodedData))
+            } catch {
+                completion(.failure(error))
+            }
+        }
     }
     
     func fetchIssues(completion: @escaping ([Issue]?) -> Void) {
@@ -44,7 +73,7 @@ class NetworkManager {
         }
     }
     
-    func fetchIssueDetail(issueId: Int, completion: @escaping (IssueDetail?) -> Void) {
+    func fetchIssueDetail(issueId: Int, completion: @escaping (IssueDetailResponse?) -> Void) {
         guard let url = URL(string: URLDefines.issue + "/\(issueId)") else {
             completion(nil)
             return
@@ -59,7 +88,7 @@ class NetworkManager {
             }
             
             do {
-                let issueDetail = try JSONDecoder().decode(IssueDetail.self, from: data)
+                let issueDetail = try JSONDecoder().decode(IssueDetailResponse.self, from: data)
                 self.prettyPrintJSON(issueDetail)
                 completion(issueDetail)
                 return
@@ -109,6 +138,46 @@ class NetworkManager {
                 return
             }
             completion(true)
+        }
+    }
+    
+    func createIssue(issueCreationRequest: IssueCreationRequest, completion: @escaping (Bool, IssueDetailResponse?) -> Void) {
+        guard let url = URL(string: URLDefines.issue) else {
+            completion(false, nil)
+            return
+        }
+        guard let token = token else { return }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = HTTPMethod.post.rawValue
+        request.addValue(token, forHTTPHeaderField: "Authorization")
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        do {
+            let jsonData = try JSONEncoder().encode(issueCreationRequest)
+            request.httpBody = jsonData
+        } catch {
+            os_log("[ createIssue ]: \(error)")
+            completion(false, nil)
+            return
+        }
+        
+        httpManager.sendRequest(request) { data, response, error in
+            guard let data = data, error == nil,
+                  let response = response, (200..<300).contains(response.statusCode) else {
+                os_log("[ createIssue ] : \(String(describing: error?.localizedDescription))\n[ statusCode ]: \(String(describing: response?.statusCode))")
+                
+                completion(false, nil)
+                return
+            }
+            
+            do {
+                let decodedIssue = try JSONDecoder().decode(IssueDetailResponse.self, from: data)
+                completion(true, decodedIssue)
+            } catch {
+                os_log("[ createIssue ] : \(String(describing: error))")
+                completion(false, nil)
+            }
         }
     }
     

--- a/ios/issue-tracker-01/issue-tracker-01/URLDefines/URLDefines.swift
+++ b/ios/issue-tracker-01/issue-tracker-01/URLDefines/URLDefines.swift
@@ -22,4 +22,5 @@ enum URLDefines {
     static let labelList = "\(base)/label/list"
     static let milestone = "\(base)/milestone"
     static let milestoneList = "\(base)/milestone/list"
+    static let select = "\(base)/select"
 }


### PR DESCRIPTION
# 🎯주요 작업

- [x]  이슈상세 피드백 개선
- [x]  새 이슈 작성

# 📚학습 키워드

**Result Type**

기존에 Result를 사용하지 않을 때는 Error가 나타나면 어떤 과정인지 파악하기 힘들었는데, Result 타입을 사용하니깐, 성공과 실패를 나눠서 처리해야 하기 때문에 가독성이 더 좋고, 에러구분을 명확히 확인할 수 있었다.

 **if case let** 

```swift
if case .assignee(let assignee) = option {
		return assignee
}
```

**고차함수 compactMap**

```swift
let assignees = options.compactMap { option -> AssigneeResponse? in
               if case .assignee(let assignee) = option {
                   return assignee
               }
               return nil
           }
```

nil을 걸러주고, 옵셔널타입은 벗겨줌

→ 맨날 Map이랑 compactMap이랑 헷갈렸는데, 필요성을 느끼고 찾아서 직접 적용해보면서 나중에도 기억이 날 것 같다!

**고차함수 Map**

```swift
 editorOptionVC.selectedOptions = selectedAssignees.map { OptionType.assignee($0) } 
```

selectedAssignees의 배열요소를 OptionType.assignee로 변환하는 과정을 거친다. 

**제약조건 충돌경고 해결**

→ 제약조건 노란색 충돌경고뜨는게 보기가 싫어서 해결하는데 시간이 오래걸렸다. 경고에서 알려주는 컴포넌트 객체의 주소를 알려주는데, 

디버거 콘솔에서 po 명령어를 사용해서, 어디가 충돌이 나는지 유추가 가능했고, 높이와 상하 제약조건을 건들여보니깐 해결이 되었다. 

아직 완전히 이해를 한 것은 아니지만 집요하게 파고들어서 해결되니 뿌듯하였습니다.

<img width="1001" alt="스크린샷 2024-05-25 오후 10 52 44" src="https://github.com/codesquad-members-2024/issue-tracker/assets/104732020/e98224e4-5b0b-41b4-b3cb-178d06129507">



# 🤔고민

라벨 삭제 처리방식과 마일스톤 삭제 처리방식이 왜 다를까?

→  라벨의 경우 비동기 삭제 완료 후 명시적으로 셀을 삭제하는 반면, 

마일스톤은 삭제 요청과 함께 바로 `completionHandler`를 호출하여 테이블뷰의 상태 갱신이 비동기적으로 이루어 진다.

- 라벨의 삭제는 삭제 성공을 확인한 후에 UI가 갱신되므로 UI와 상태가 동기화
- 마일스톤은 상태 변화를 비동기적으로 감지하고 이에 따라 UI가 업데이트되므로 동기화 타이밍에 차이가 발생

setSelected(_ selected: Bool, animated: Bool) 를 사용해서 circleImage를 바꾸게 하고 싶었는데, setSelected호출할 때와 테이블뷰의 셀 재사용 타이밍이나 didSelectRowAt 타이밍이 엇갈려서 동기화가 안되서 그런지, 내가 의도한대로 되질 않음.

→ 해당변수가 값이 변경될 때마다 속성에 감시를 하여서 내가 원하는 동작이 되도록 의도함.

추가정보의 뷰컨트롤러의 재사용을 하기위해서 

- enum으로 OptionType도 만들어서 구분되게 의도하고..
- 휴대폰은 화면이 작기 떄문에, 레이블이나 담당자는 여러개  선택하면, 사용자 입장에서 컬렉션뷰를 이용해서 확인하면 좋겠다고 생각하여서 구현했는데.. 너무나 복잡하다..
- swiftLint한테 함수안은 복잡하면 안된다고 cyclomatic_complexity 혼났다 ㅠ_ㅠ (  switch문에서 case가 많아지면 이를 어떻게 극복하지… )

# 💻결과 (마일스톤 1대1 대응/ 추가 정보 선택/ 최종 이슈결과화면)
![이슈작성결과](https://github.com/codesquad-members-2024/issue-tracker/assets/104732020/f78e4c11-b1de-47ef-8c99-502b0985e492)

