### PR TITLE
깃허브 로그인 구현, 라벨 수정/이슈 필터링 카운트 기능 수정

### DIFF
--- a/.github/workflows/server-cd.yml
+++ b/.github/workflows/server-cd.yml
@@ -3,9 +3,9 @@ name: Deploy Spring Application to Ec2
 # 임시로 배포 브랜치 be/solve로 설정
 on: 
   push:
-    branches: [ "be/solve" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "be/solve" ]
+    branches: [ "main" ]
 
 # 워크플로우가 저장소의 콘텐츠를 읽을 수 있는 권한을 갖도록 설정
 permissions: 

--- a/.github/workflows/server-cd.yml
+++ b/.github/workflows/server-cd.yml
@@ -33,7 +33,9 @@ jobs:
           cd resources
           mkdir ssl
           cd ssl
-          echo "$KEYSTORE_P12" | base64 -d > keystore.p12
+          touch keystore.p12
+          echo "${{ secrets.KEYSTORE_P12 }}" | base64 -d > ./keystore.p12
+        shell: bash
           
       - name: Make application.properties
         run: |

--- a/.github/workflows/server-cd.yml
+++ b/.github/workflows/server-cd.yml
@@ -1,6 +1,5 @@
 name: Deploy Spring Application to Ec2
 
-# 임시로 배포 브랜치 be/solve로 설정
 on: 
   push:
     branches: [ "main" ]

--- a/.github/workflows/server-cd.yml
+++ b/.github/workflows/server-cd.yml
@@ -23,12 +23,21 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: '17'
-          
-      - name: Make application.properties
+
+      - name: Make KeyStore
+        env:
+          KEYSTORE_P12: ${{ secrets.KEYSTORE_P12 }}
         run: |
           cd ./be/issue-tracker/src/main
           mkdir resources
           cd resources
+          mkdir ssl
+          cd ssl
+          echo "$KEYSTORE_P12" | base64 -d > keystore.p12
+          
+      - name: Make application.properties
+        run: |
+          cd ./be/issue-tracker/src/main/resources
           touch application.properties
           echo "${{ secrets.PROPERTIES }}" > ./application.properties
         shell: bash

--- a/be/issue-tracker/Dockerfile
+++ b/be/issue-tracker/Dockerfile
@@ -1,5 +1,7 @@
 FROM amazoncorretto:17
 EXPOSE 8080
+EXPOSE 443
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
+COPY src/main/resources/ssl/keystore.p12 /app/resources/ssl/keystore.p12
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/be/issue-tracker/Dockerfile
+++ b/be/issue-tracker/Dockerfile
@@ -1,7 +1,5 @@
 FROM amazoncorretto:17
 EXPOSE 8080
-EXPOSE 443
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
-COPY src/main/resources/ssl/keystore.p12 /app/resources/ssl/keystore.p12
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/be/issue-tracker/build.gradle
+++ b/be/issue-tracker/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.1'
     implementation 'org.apache.tika:tika-core:2.9.1'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
 
 
     compileOnly 'org.projectlombok:lombok'

--- a/be/issue-tracker/src/main/java/com/issuetracker/WebClientConfig.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/WebClientConfig.java
@@ -1,0 +1,13 @@
+package com.issuetracker;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+}

--- a/be/issue-tracker/src/main/java/com/issuetracker/WebConfig.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/WebConfig.java
@@ -17,7 +17,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOriginPatterns("https://issue-tracker.site/*:443", "http://*:3000")
+                .allowedOriginPatterns("https://issue-tracker.site", "http://*:3000")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/be/issue-tracker/src/main/java/com/issuetracker/WebConfig.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/WebConfig.java
@@ -17,7 +17,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOriginPatterns("http://*:3000")
+                .allowedOriginPatterns("https://issue-tracker.site/*:443", "http://*:3000")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/be/issue-tracker/src/main/java/com/issuetracker/file/util/CustomMultipartFile.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/file/util/CustomMultipartFile.java
@@ -5,12 +5,15 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import org.apache.tika.Tika;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
  * byte 배열을 MultipartFile 객체로 변환하기 위한 클래스
  */
 public class CustomMultipartFile implements MultipartFile {
+    private final Tika tika = new Tika();
+
     private byte[] input;
     private String filename;
 
@@ -21,7 +24,7 @@ public class CustomMultipartFile implements MultipartFile {
 
     @Override
     public String getName() {
-        return null;
+        return filename;
     }
 
     @Override
@@ -31,7 +34,11 @@ public class CustomMultipartFile implements MultipartFile {
 
     @Override
     public String getContentType() {
-        return null;
+        try {
+            return tika.detect(getInputStream());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/be/issue-tracker/src/main/java/com/issuetracker/file/util/CustomMultipartFile.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/file/util/CustomMultipartFile.java
@@ -1,0 +1,63 @@
+package com.issuetracker.file.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * byte 배열을 MultipartFile 객체로 변환하기 위한 클래스
+ */
+public class CustomMultipartFile implements MultipartFile {
+    private byte[] input;
+    private String filename;
+
+    public CustomMultipartFile(byte[] input, String filename) {
+        this.input = input;
+        this.filename = filename;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public String getOriginalFilename() {
+        return filename;
+    }
+
+    @Override
+    public String getContentType() {
+        return null;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return input == null || input.length == 0;
+    }
+
+    @Override
+    public long getSize() {
+        return input.length;
+    }
+
+    @Override
+    public byte[] getBytes() {
+        return input;
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return new ByteArrayInputStream(input);
+    }
+
+    @Override
+    public void transferTo(File dest) throws IOException, IllegalStateException {
+        try (FileOutputStream fos = new FileOutputStream(dest)) {
+            fos.write(input);
+        }
+    }
+}

--- a/be/issue-tracker/src/main/java/com/issuetracker/file/util/ImgUrlConverter.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/file/util/ImgUrlConverter.java
@@ -1,0 +1,24 @@
+package com.issuetracker.file.util;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import javax.imageio.ImageIO;
+import org.springframework.web.multipart.MultipartFile;
+
+public class ImgUrlConverter {
+    public static MultipartFile toMultipartFile(String imgUrl) throws MalformedURLException {
+        URL url = new URL(imgUrl);
+        try (InputStream inputStream = url.openStream(); ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            BufferedImage urlImage = ImageIO.read(inputStream);
+            ImageIO.write(urlImage, "jpg", bos);
+            byte[] byteArray = bos.toByteArray();
+            return new CustomMultipartFile(byteArray, imgUrl);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/be/issue-tracker/src/main/java/com/issuetracker/global/controller/HomeController.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/global/controller/HomeController.java
@@ -1,5 +1,6 @@
 package com.issuetracker.global.controller;
 
+import com.issuetracker.global.dto.HomeComponentResponse;
 import com.issuetracker.global.dto.HomeIssueResponse;
 import com.issuetracker.global.service.HomeService;
 import com.issuetracker.issue.dto.IssueQueryDto;
@@ -15,6 +16,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class HomeController {
     private final HomeService homeService;
+
+    @GetMapping("/components")
+    public ResponseEntity<HomeComponentResponse> getComponents() {
+        HomeComponentResponse homeComponentResponse = homeService.getComponents();
+        return ResponseEntity.ok().body(homeComponentResponse);
+    }
 
     @GetMapping("/issues")
     public ResponseEntity<HomeIssueResponse> getFilteredIssues(@ModelAttribute IssueQueryDto issueQueryDto) {

--- a/be/issue-tracker/src/main/java/com/issuetracker/global/dto/HomeComponentResponse.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/global/dto/HomeComponentResponse.java
@@ -1,9 +1,7 @@
 package com.issuetracker.global.dto;
 
-import com.issuetracker.label.dto.LabelListDto;
-import com.issuetracker.member.dto.SimpleMemberDto;
-import com.issuetracker.milestone.dto.MilestoneListDto;
-import java.util.List;
+import com.issuetracker.label.dto.LabelCountDto;
+import com.issuetracker.milestone.dto.MilestoneCountDto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -12,8 +10,6 @@ import lombok.ToString;
 @ToString
 @Builder
 public class HomeComponentResponse {
-    private final List<SimpleMemberDto> assignees;
-    private final LabelListDto labels;
-    private final MilestoneListDto milestones;
-    private final List<SimpleMemberDto> authors;
+    private final LabelCountDto labelCount;
+    private final MilestoneCountDto milestoneCount;
 }

--- a/be/issue-tracker/src/main/java/com/issuetracker/global/service/HomeService.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/global/service/HomeService.java
@@ -2,11 +2,12 @@ package com.issuetracker.global.service;
 
 import com.issuetracker.global.dto.HomeComponentResponse;
 import com.issuetracker.global.dto.HomeIssueResponse;
+import com.issuetracker.issue.dto.IssueFilterResult;
 import com.issuetracker.issue.dto.IssueQueryDto;
 import com.issuetracker.issue.service.IssueFilterService;
-import com.issuetracker.issue.service.IssueQueryService;
 import com.issuetracker.label.service.LabelService;
 import com.issuetracker.milestone.service.MilestoneService;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -16,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class HomeService {
-    private final IssueQueryService issueQueryService;
     private final IssueFilterService issueFilterService;
     private final LabelService labelService;
     private final MilestoneService milestoneService;
@@ -37,9 +37,10 @@ public class HomeService {
      */
     @Transactional(readOnly = true)
     public HomeIssueResponse getFilteredIssues(IssueQueryDto issueQueryDto) {
+        Set<IssueFilterResult> filteredIssues = issueFilterService.filterIssues(issueQueryDto);
         return HomeIssueResponse.builder()
-                .count(issueQueryService.countIssues())
-                .filteredIssues(issueFilterService.getFilteredIssues(issueQueryDto))
+                .count(issueFilterService.countFilteredIssues(filteredIssues))
+                .filteredIssues(issueFilterService.getIssueFilterResponse(issueQueryDto.getIsClosed(), filteredIssues))
                 .build();
     }
 }

--- a/be/issue-tracker/src/main/java/com/issuetracker/global/service/HomeService.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/global/service/HomeService.java
@@ -6,7 +6,6 @@ import com.issuetracker.issue.dto.IssueQueryDto;
 import com.issuetracker.issue.service.IssueFilterService;
 import com.issuetracker.issue.service.IssueQueryService;
 import com.issuetracker.label.service.LabelService;
-import com.issuetracker.member.service.MemberService;
 import com.issuetracker.milestone.service.MilestoneService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,18 +20,15 @@ public class HomeService {
     private final IssueFilterService issueFilterService;
     private final LabelService labelService;
     private final MilestoneService milestoneService;
-    private final MemberService memberService;
 
     /**
-     * 홈 화면의 상위 컴포넌트를 반환한다.
+     * 라벨의 개수와 마일스톤의 개수를 나타내는 홈 화면의 상위 컴포넌트를 반환한다.
      */
     @Transactional(readOnly = true)
     public HomeComponentResponse getComponents() {
         return HomeComponentResponse.builder()
-                .assignees(memberService.getMembers())
-                .labels(labelService.getLabelListDto())
-                .milestones(milestoneService.showMilestoneList(false))
-                .authors(memberService.getMembers())
+                .labelCount(labelService.countLabels())
+                .milestoneCount(milestoneService.countMilestones())
                 .build();
     }
 

--- a/be/issue-tracker/src/main/java/com/issuetracker/global/util/IssueFilterQueryGenerator.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/global/util/IssueFilterQueryGenerator.java
@@ -18,71 +18,77 @@ public class IssueFilterQueryGenerator {
 
     public Map<String, Object> generate(Long labelId, Long milestoneId) {
         Map<String, Object> result = new HashMap<>();
-        StringBuilder sql = new StringBuilder("SELECT i.id, i.title, i.create_date, m.name " +
+        StringBuilder sql = new StringBuilder("SELECT i.id, i.title, i.create_date, i.is_closed, i.member_id, m.name " +
                 "FROM issue i " +
                 "LEFT JOIN issue_label il ON i.id = il.issue_id " +
                 "LEFT JOIN issue_assignee ia ON i.id = ia.issue_id " +
                 "LEFT JOIN comment c ON i.id = c.issue_id " +
-                "LEFT JOIN milestone m ON i.milestone_id = m.id " +
-                "WHERE i.is_closed = ? ");
+                "LEFT JOIN milestone m ON i.milestone_id = m.id");
 
+        List<String> conditions = new ArrayList<>();
         List<Object> params = new ArrayList<>();
-        params.add(issueQueryDto.getIsClosed()); // 열림/닫힘 여부는 기본으로 설정되어 있는 필터
 
-        appendAuthorFilter(sql, params, issueQueryDto.getAuthorId());
-        appendAssigneeFilter(sql, params, issueQueryDto.getAssigneeId());
-        appendMentionedFilter(sql, params, issueQueryDto.getMentionedId());
-        appendLabelFilter(sql, params, labelId);
-        appendMilestoneFilter(sql, params, milestoneId);
-
-        sql.append("ORDER BY i.create_date DESC, i.id DESC;"); // 최신순으로 정렬.
+        appendAuthorFilter(conditions, params, issueQueryDto.getAuthorId());
+        appendAssigneeFilter(conditions, params, issueQueryDto.getAssigneeId());
+        appendMentionedFilter(conditions, params, issueQueryDto.getMentionedId());
+        appendLabelFilter(conditions, params, labelId);
+        appendMilestoneFilter(conditions, params, milestoneId);
+        appendConditions(conditions, sql);
+        sql.append(" ORDER BY i.create_date DESC, i.id DESC;"); // 최신순으로 정렬
 
         result.put("params", params.toArray());
         result.put("sql", sql.toString());
         return result;
     }
 
-    private void appendAuthorFilter(StringBuilder sql, List<Object> params, String authorId) {
+    private void appendAuthorFilter(List<String> conditions, List<Object> params, String authorId) {
         if (StringUtils.hasText(authorId)) { // 작성자 필터 조건이 있다면
-            sql.append("AND i.member_id = ? ");
+            conditions.add("i.member_id = ?");
             params.add(authorId);
         }
     }
 
-    private void appendAssigneeFilter(StringBuilder sql, List<Object> params, String assigneeId) {
+    private void appendAssigneeFilter(List<String> conditions, List<Object> params, String assigneeId) {
         if (StringUtils.hasText(assigneeId)) { // 담당자 필터 조건이 있다면
-            sql.append("AND ia.member_id = ? ");
+            conditions.add("ia.member_id = ?");
             params.add(assigneeId);
         }
         if (noValues.contains("assignee")) { // 담당자가 없는 필터 조건
-            sql.append("AND ia.member_id IS NULL ");
+            conditions.add("ia.member_id IS NULL");
         }
     }
 
-    private void appendMentionedFilter(StringBuilder sql, List<Object> params, String mentionedId) {
+    private void appendMentionedFilter(List<String> conditions, List<Object> params, String mentionedId) {
         if (StringUtils.hasText(mentionedId)) { // 댓글을 작성한 사용자 필터 조건이 있다면
-            sql.append("AND c.member_id = ? ");
+            conditions.add("c.member_id = ?");
             params.add(mentionedId);
         }
     }
 
-    private void appendLabelFilter(StringBuilder sql, List<Object> params, Long labelId) {
+    private void appendLabelFilter(List<String> conditions, List<Object> params, Long labelId) {
         if (labelId != null) { // 라벨 필터 조건이 있다면
-            sql.append("AND il.label_id = ? ");
+            conditions.add("il.label_id = ?");
             params.add(labelId);
         }
         if (noValues.contains("label")) { // 라벨이 없는 필터 조건
-            sql.append("AND il.label_id IS NULL ");
+            conditions.add("il.label_id IS NULL");
         }
     }
 
-    private void appendMilestoneFilter(StringBuilder sql, List<Object> params, Long milestoneId) {
+    private void appendMilestoneFilter(List<String> conditions, List<Object> params, Long milestoneId) {
         if (milestoneId != null) { // 마일스톤 필터 조건이 있다면
-            sql.append("AND i.milestone_id = ? ");
+            conditions.add("i.milestone_id = ?");
             params.add(milestoneId);
         }
         if (noValues.contains("milestone")) {  // 마일스톤이 없는 필터 조건
-            sql.append("AND i.milestone_id IS NULL ");
+            conditions.add("i.milestone_id IS NULL");
+        }
+    }
+
+    private void appendConditions(List<String> conditions, StringBuilder sql) {
+        if (!conditions.isEmpty()) {
+            sql.append(" WHERE ");
+            sql.append(String.join(" AND ", conditions));
         }
     }
 }

--- a/be/issue-tracker/src/main/java/com/issuetracker/issue/dto/IssueCountDto.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/issue/dto/IssueCountDto.java
@@ -8,6 +8,6 @@ import lombok.ToString;
 @ToString
 @RequiredArgsConstructor
 public class IssueCountDto {
-    private final long openedIssueCount;
-    private final long closedIssueCount;
+    private final long openedCount;
+    private final long closedCount;
 }

--- a/be/issue-tracker/src/main/java/com/issuetracker/issue/dto/IssueFilterResult.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/issue/dto/IssueFilterResult.java
@@ -1,0 +1,22 @@
+package com.issuetracker.issue.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+@Builder
+@EqualsAndHashCode
+public class IssueFilterResult {
+    private final Long id;
+    private final String title;
+    private final LocalDateTime createDate;
+    private final Boolean isClosed;
+    private final String authorId;
+    private final String milestoneName;
+    private final String closedCount;
+    private final String openCount;
+}

--- a/be/issue-tracker/src/main/java/com/issuetracker/issue/repository/IssueAssigneeRepository.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/issue/repository/IssueAssigneeRepository.java
@@ -11,9 +11,6 @@ import org.springframework.data.repository.CrudRepository;
 public interface IssueAssigneeRepository extends CrudRepository<IssueAssignee, Long>, WithInsert<IssueAssignee> {
     Optional<IssueAssignee> findByIssueIdAndMemberId(Long issueId, String memberId);
 
-    @Query("SELECT member_id FROM issue_assignee where issue_id = :issueId")
-    List<String> findAllByIssueId(Long issueId);
-
     @Query("SELECT member_id FROM issue_assignee WHERE issue_id = :issueId")
     List<String> findAssigneeIdsByIssueId(Long issueId);
 

--- a/be/issue-tracker/src/main/java/com/issuetracker/issue/repository/IssueCustomRepository.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/issue/repository/IssueCustomRepository.java
@@ -1,10 +1,10 @@
 package com.issuetracker.issue.repository;
 
-import com.issuetracker.issue.dto.IssueFilterResponse;
+import com.issuetracker.issue.dto.IssueFilterResult;
 import com.issuetracker.issue.dto.IssueQueryDto;
 import java.util.Map;
 import java.util.Set;
 
 public interface IssueCustomRepository {
-    Set<IssueFilterResponse> findIssueWithFilter(Map<String, Object> filter, IssueQueryDto issueQueryDto);
+    Set<IssueFilterResult> findIssueWithFilter(Map<String, Object> filter, IssueQueryDto issueQueryDto);
 }

--- a/be/issue-tracker/src/main/java/com/issuetracker/issue/repository/IssueCustomRepositoryImpl.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/issue/repository/IssueCustomRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.issuetracker.issue.repository;
 
-import com.issuetracker.issue.dto.IssueFilterResponse;
+import com.issuetracker.issue.dto.IssueFilterResult;
 import com.issuetracker.issue.dto.IssueQueryDto;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -17,18 +17,20 @@ public class IssueCustomRepositoryImpl implements IssueCustomRepository {
     private final JdbcTemplate jdbcTemplate;
 
     @Override
-    public Set<IssueFilterResponse> findIssueWithFilter(Map<String, Object> filter, IssueQueryDto issueQueryDto) {
+    public Set<IssueFilterResult> findIssueWithFilter(Map<String, Object> filter, IssueQueryDto issueQueryDto) {
         String sql = (String) filter.get("sql");
         Object[] params = (Object[]) filter.get("params");
-        List<IssueFilterResponse> result = jdbcTemplate.query(sql, params, issueFilterDtoMapper());
+        List<IssueFilterResult> result = jdbcTemplate.query(sql, params, issueFilterDtoMapper());
         return new LinkedHashSet<>(result);
     }
 
-    private RowMapper<IssueFilterResponse> issueFilterDtoMapper() {
-        return (rs, rowNum) -> (IssueFilterResponse.builder()
-                .id(rs.getLong("id"))
+    private RowMapper<IssueFilterResult> issueFilterDtoMapper() {
+        return (rs, rowNum) -> (IssueFilterResult.builder()
+                .id(rs.getLong("i.id"))
                 .title(rs.getString("title"))
-                .createDate(rs.getTimestamp("create_date").toLocalDateTime())
+                .createDate(rs.getTimestamp("i.create_date").toLocalDateTime())
+                .isClosed(rs.getBoolean("i.is_closed"))
+                .authorId(rs.getString("i.member_id"))
                 .milestoneName(rs.getString("name"))
                 .build()
         );

--- a/be/issue-tracker/src/main/java/com/issuetracker/issue/util/IssueMapper.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/issue/util/IssueMapper.java
@@ -4,6 +4,7 @@ import com.issuetracker.comment.dto.CommentDetailDto;
 import com.issuetracker.file.dto.UploadedFileDto;
 import com.issuetracker.issue.dto.IssueDetailDto;
 import com.issuetracker.issue.dto.IssueFilterResponse;
+import com.issuetracker.issue.dto.IssueFilterResult;
 import com.issuetracker.issue.entity.Issue;
 import com.issuetracker.label.dto.LabelCoverDto;
 import com.issuetracker.label.entity.Label;
@@ -12,19 +13,19 @@ import com.issuetracker.milestone.dto.SimpleMilestoneDto;
 import java.util.List;
 
 public class IssueMapper {
-    public static IssueFilterResponse toIssueFilterResponse(IssueFilterResponse filterResponse,
+    public static IssueFilterResponse toIssueFilterResponse(IssueFilterResult filterResult,
                                                             SimpleMemberDto author,
                                                             List<SimpleMemberDto> assignees,
                                                             List<LabelCoverDto> labels) {
-        Long filterId = filterResponse.getId();
+        Long filterId = filterResult.getId();
         return IssueFilterResponse.builder()
                 .id(filterId)
-                .title(filterResponse.getTitle())
+                .title(filterResult.getTitle())
                 .author(author)
-                .createDate(filterResponse.getCreateDate())
+                .createDate(filterResult.getCreateDate())
                 .assignees(assignees)
                 .labels(labels)
-                .milestoneName(filterResponse.getMilestoneName())
+                .milestoneName(filterResult.getMilestoneName())
                 .build();
     }
 

--- a/be/issue-tracker/src/main/java/com/issuetracker/label/entity/Label.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/label/entity/Label.java
@@ -16,7 +16,6 @@ public class Label {
     private final Long id;
     private final String name;
     private final String description;
-    @Column("text_color")
     private final String textColor;
     @Column("background_color")
     private final String bgColor;

--- a/be/issue-tracker/src/main/java/com/issuetracker/label/repository/LabelRepository.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/label/repository/LabelRepository.java
@@ -7,6 +7,9 @@ import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.repository.CrudRepository;
 
 public interface LabelRepository extends CrudRepository<Label, Long> {
+    @Query("SELECT id, name, description, text_color, background_color FROM label ORDER BY id DESC;")
+    List<Label> findAll();
+
     @Query("SELECT name, text_color, background_color FROM label WHERE id IN (:ids)")
     List<LabelCoverDto> findLabelCoverDtoByIds(List<Long> ids);
 

--- a/be/issue-tracker/src/main/java/com/issuetracker/label/service/LabelService.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/label/service/LabelService.java
@@ -1,6 +1,7 @@
 package com.issuetracker.label.service;
 
 import com.issuetracker.label.dto.LabelBgColorDto;
+import com.issuetracker.label.dto.LabelCountDto;
 import com.issuetracker.label.dto.LabelCoverDto;
 import com.issuetracker.label.dto.LabelDto;
 import com.issuetracker.label.dto.LabelListDto;
@@ -22,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class LabelService {
     private final LabelRepository labelRepository;
     private final HexColorGenerator hexColorGenerator;
-    
+
     /**
      * 라벨의 개수와 함께 라벨의 전체 리스트를 반환한다.
      */
@@ -100,6 +101,15 @@ public class LabelService {
      */
     public LabelBgColorDto refreshLabelBackgroundColor() {
         return new LabelBgColorDto(hexColorGenerator.generateRandomHexColor());
+    }
+
+    /**
+     * 라벨의 총 개수를 반환한다.
+     */
+    @Transactional(readOnly = true)
+    public LabelCountDto countLabels() {
+        long count = labelRepository.countAll();
+        return new LabelCountDto(count);
     }
 
     private void validateLabelExists(Long id) {

--- a/be/issue-tracker/src/main/java/com/issuetracker/label/service/LabelService.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/label/service/LabelService.java
@@ -11,6 +11,7 @@ import com.issuetracker.label.exception.LabelNotFoundException;
 import com.issuetracker.label.repository.LabelRepository;
 import com.issuetracker.label.util.BackgroundColorValidator;
 import com.issuetracker.label.util.HexColorGenerator;
+import com.issuetracker.label.util.LabelMapper;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,7 +31,7 @@ public class LabelService {
     @Transactional(readOnly = true)
     public LabelListDto getLabelListDto() {
         long count = labelRepository.countAll();
-        List<Label> labels = (List<Label>) labelRepository.findAll();
+        List<Label> labels = labelRepository.findAll();
         return new LabelListDto(count, labels);
     }
 
@@ -41,7 +42,7 @@ public class LabelService {
     public Label createLabel(LabelDto labelDto) {
         validateBgColor(labelDto);
 
-        Label label = toLabel(labelDto);
+        Label label = LabelMapper.toLabel(labelDto);
         Label savedLabel = labelRepository.save(label);
         log.info("새로운 라벨이 생성되었습니다. - {}", savedLabel);
         return savedLabel;
@@ -54,7 +55,7 @@ public class LabelService {
     public Label modifyLabel(LabelDto labelDto, Long id) {
         validateBgColor(labelDto);
 
-        Label label = toLabel(labelDto);
+        Label label = LabelMapper.toModifiedLabel(id, labelDto);
         Label modifiedlabel = labelRepository.save(label);
         log.info("{} 라벨이 수정되었습니다. - {}", id, modifiedlabel);
         return modifiedlabel;
@@ -124,10 +125,5 @@ public class LabelService {
         if (!BackgroundColorValidator.isHex(bgColor)) {
             throw new InvalidBgColorException();
         }
-    }
-
-    private Label toLabel(LabelDto labelDto) {
-        return new Label(null, labelDto.getName(), labelDto.getDescription(), labelDto.getTextColor(),
-                labelDto.getBgColor());
     }
 }

--- a/be/issue-tracker/src/main/java/com/issuetracker/label/util/LabelMapper.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/label/util/LabelMapper.java
@@ -1,0 +1,16 @@
+package com.issuetracker.label.util;
+
+import com.issuetracker.label.dto.LabelDto;
+import com.issuetracker.label.entity.Label;
+
+public class LabelMapper {
+    public static Label toLabel(LabelDto labelDto) {
+        return new Label(null, labelDto.getName(), labelDto.getDescription(), labelDto.getTextColor(),
+                labelDto.getBgColor());
+    }
+
+    public static Label toModifiedLabel(Long id, LabelDto labelDto) {
+        return new Label(id, labelDto.getName(), labelDto.getDescription(), labelDto.getTextColor(),
+                labelDto.getBgColor());
+    }
+}

--- a/be/issue-tracker/src/main/java/com/issuetracker/member/controller/MemberController.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.issuetracker.member.dto.MemberCreateDto;
 import com.issuetracker.member.dto.SimpleMemberDto;
 import com.issuetracker.member.entity.Member;
 import com.issuetracker.member.service.MemberService;
+import com.issuetracker.member.util.MemberMapper;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
@@ -30,7 +31,7 @@ public class MemberController {
 
     @PostMapping
     public ResponseEntity<Member> createMember(@Valid @RequestBody MemberCreateDto memberCreateDto) {
-        Member member = memberService.create(memberCreateDto);
+        Member member = memberService.create(MemberMapper.toMember(memberCreateDto));
         URI location = URI.create(String.format("/api/members/%s", member.getId()));
         return ResponseEntity.created(location).body(member);
     }

--- a/be/issue-tracker/src/main/java/com/issuetracker/member/service/MemberService.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/member/service/MemberService.java
@@ -2,7 +2,6 @@ package com.issuetracker.member.service;
 
 import com.issuetracker.file.dto.UploadedFileDto;
 import com.issuetracker.file.service.FileService;
-import com.issuetracker.member.dto.MemberCreateDto;
 import com.issuetracker.member.dto.SimpleMemberDto;
 import com.issuetracker.member.entity.Member;
 import com.issuetracker.member.exception.MemberNotFoundException;
@@ -28,8 +27,7 @@ public class MemberService {
      * 멤버의 아이디가 중복이 아니라면 새로운 멤버를 생성한다.
      */
     @Transactional
-    public Member create(MemberCreateDto memberCreateDto) {
-        Member member = MemberMapper.toMember(memberCreateDto);
+    public Member create(Member member) {
         Member created = memberRepository.insert(member);
 
         log.info("새로운 유저가 생성되었습니다. {}", created);

--- a/be/issue-tracker/src/main/java/com/issuetracker/member/service/MemberService.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/member/service/MemberService.java
@@ -60,6 +60,19 @@ public class MemberService {
         return MemberMapper.toSimpleMemberDto(member, imgUrl);
     }
 
+    /**
+     * 회원가입되어 있는 사용자인지 확인한다.
+     */
+    @Transactional(readOnly = true)
+    public boolean isNewUser(String id) {
+        try {
+            getMemberOrThrow(id);
+        } catch (MemberNotFoundException e) {
+            return true;
+        }
+        return false;
+    }
+
     private boolean isUserDeactivated(String id) {
         return !StringUtils.hasText(id);
     }

--- a/be/issue-tracker/src/main/java/com/issuetracker/member/util/MemberMapper.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/member/util/MemberMapper.java
@@ -13,9 +13,9 @@ public class MemberMapper {
                 memberCreateDto.getNickname(), memberCreateDto.getEmail(), null);
     }
 
-    public static MemberCreateDto toMemberCreateDto(GithubProfile profile) {
+    public static Member toMember(GithubProfile profile, Long fileId) {
         String uuidPw = UUID.randomUUID().toString().substring(0, 12); // 깃허브로 가입한 사용자는 비밀번호를 UUID로 설정
-        return new MemberCreateDto(profile.getId(), uuidPw, profile.getNickname(), profile.getEmail());
+        return new Member(profile.getId(), uuidPw, profile.getNickname(), profile.getEmail(), fileId);
     }
 
     public static SimpleMemberDto toSimpleMemberDto(Member member, String imgUrl) {

--- a/be/issue-tracker/src/main/java/com/issuetracker/member/util/MemberMapper.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/member/util/MemberMapper.java
@@ -3,12 +3,19 @@ package com.issuetracker.member.util;
 import com.issuetracker.member.dto.MemberCreateDto;
 import com.issuetracker.member.dto.SimpleMemberDto;
 import com.issuetracker.member.entity.Member;
+import com.issuetracker.oauth.dto.GithubProfile;
+import java.util.UUID;
 
 public class MemberMapper {
 
     public static Member toMember(MemberCreateDto memberCreateDto) {
         return new Member(memberCreateDto.getId(), memberCreateDto.getPassword(),
                 memberCreateDto.getNickname(), memberCreateDto.getEmail(), null);
+    }
+
+    public static MemberCreateDto toMemberCreateDto(GithubProfile profile) {
+        String uuidPw = UUID.randomUUID().toString().substring(0, 12); // 깃허브로 가입한 사용자는 비밀번호를 UUID로 설정
+        return new MemberCreateDto(profile.getId(), uuidPw, profile.getNickname(), profile.getEmail());
     }
 
     public static SimpleMemberDto toSimpleMemberDto(Member member, String imgUrl) {

--- a/be/issue-tracker/src/main/java/com/issuetracker/oauth/controller/GithubLoginController.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/oauth/controller/GithubLoginController.java
@@ -1,0 +1,26 @@
+package com.issuetracker.oauth.controller;
+
+import com.issuetracker.oauth.dto.GithubProfile;
+import com.issuetracker.oauth.service.GithubLoginService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/oauth/github")
+@RequiredArgsConstructor
+public class GithubLoginController {
+    private final GithubLoginService githubLoginService;
+
+    @GetMapping("/callback")
+    public ResponseEntity<GithubProfile> login(HttpServletResponse response, @RequestParam String code) {
+        String accessToken = githubLoginService.getAccessToken(code);
+        GithubProfile profile = githubLoginService.getUserInfo(accessToken);
+
+        return ResponseEntity.ok().body(profile);
+    }
+}

--- a/be/issue-tracker/src/main/java/com/issuetracker/oauth/controller/GithubLoginController.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/oauth/controller/GithubLoginController.java
@@ -1,5 +1,6 @@
 package com.issuetracker.oauth.controller;
 
+import com.issuetracker.file.dto.UploadedFileDto;
 import com.issuetracker.file.service.FileService;
 import com.issuetracker.file.util.ImgUrlConverter;
 import com.issuetracker.member.dto.LoginResponse;
@@ -32,8 +33,8 @@ public class GithubLoginController {
 
         // 처음 사용자가 깃허브 로그인을 하는 것이라면 회원가입 로직을 수행한다.
         if (memberService.isNewUser(profile.getId())) {
-            memberService.create(MemberMapper.toMemberCreateDto(profile));
-            fileService.uploadFile(ImgUrlConverter.toMultipartFile(profile.getImgUrl()));
+            UploadedFileDto file = fileService.uploadFile(ImgUrlConverter.toMultipartFile(profile.getImgUrl()));
+            memberService.create(MemberMapper.toMember(profile, file.getId()));
         }
         LoginResponse loginResponse = loginService.githubLogin(profile);
         return ResponseEntity.ok().body(loginResponse);

--- a/be/issue-tracker/src/main/java/com/issuetracker/oauth/controller/GithubLoginController.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/oauth/controller/GithubLoginController.java
@@ -1,8 +1,14 @@
 package com.issuetracker.oauth.controller;
 
+import com.issuetracker.file.service.FileService;
+import com.issuetracker.file.util.ImgUrlConverter;
+import com.issuetracker.member.dto.LoginResponse;
+import com.issuetracker.member.service.LoginService;
+import com.issuetracker.member.service.MemberService;
+import com.issuetracker.member.util.MemberMapper;
 import com.issuetracker.oauth.dto.GithubProfile;
 import com.issuetracker.oauth.service.GithubLoginService;
-import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,12 +21,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class GithubLoginController {
     private final GithubLoginService githubLoginService;
+    private final MemberService memberService;
+    private final LoginService loginService;
+    private final FileService fileService;
 
     @GetMapping("/callback")
-    public ResponseEntity<GithubProfile> login(HttpServletResponse response, @RequestParam String code) {
+    public ResponseEntity<LoginResponse> login(@RequestParam String code) throws IOException {
         String accessToken = githubLoginService.getAccessToken(code);
         GithubProfile profile = githubLoginService.getUserInfo(accessToken);
 
-        return ResponseEntity.ok().body(profile);
+        // 처음 사용자가 깃허브 로그인을 하는 것이라면 회원가입 로직을 수행한다.
+        if (memberService.isNewUser(profile.getId())) {
+            memberService.create(MemberMapper.toMemberCreateDto(profile));
+            fileService.uploadFile(ImgUrlConverter.toMultipartFile(profile.getImgUrl()));
+        }
+        LoginResponse loginResponse = loginService.githubLogin(profile);
+        return ResponseEntity.ok().body(loginResponse);
     }
 }

--- a/be/issue-tracker/src/main/java/com/issuetracker/oauth/dto/AccessTokenRequest.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/oauth/dto/AccessTokenRequest.java
@@ -1,0 +1,15 @@
+package com.issuetracker.oauth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Builder
+@ToString
+@Getter
+public class AccessTokenRequest {
+    private final String client_id;
+    private final String client_secret;
+    private final String code;
+    private final String redirect_uri;
+}

--- a/be/issue-tracker/src/main/java/com/issuetracker/oauth/dto/GithubProfile.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/oauth/dto/GithubProfile.java
@@ -1,0 +1,57 @@
+package com.issuetracker.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor
+@ToString
+public class GithubProfile {
+    private String login;
+    private String nickname;
+    private String email;
+    private String avatarUrl;
+
+    // 역직렬화할 때 사용
+    @JsonSetter("login")
+    public void setLogin(String login) {
+        this.login = login;
+    }
+
+    // 직렬화할 때 사용
+    @JsonGetter("id")
+    public String getLogin() {
+        return login;
+    }
+
+    @JsonSetter("name")
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    @JsonGetter("nickname")
+    public String getNickname() {
+        return nickname;
+    }
+
+    @JsonGetter("email")
+    public String getEmail() {
+        return email;
+    }
+
+    @JsonGetter("email")
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    @JsonSetter("avatar_url")
+    public void setAvatarUrl(String avatarUrl) {
+        this.avatarUrl = avatarUrl;
+    }
+
+    @JsonGetter("imgUrl")
+    public String getAvatarUrl() {
+        return avatarUrl;
+    }
+}

--- a/be/issue-tracker/src/main/java/com/issuetracker/oauth/dto/GithubProfile.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/oauth/dto/GithubProfile.java
@@ -8,21 +8,21 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString
 public class GithubProfile {
-    private String login;
+    private String id;
     private String nickname;
     private String email;
-    private String avatarUrl;
+    private String imgUrl;
 
     // 역직렬화할 때 사용
     @JsonSetter("login")
-    public void setLogin(String login) {
-        this.login = login;
+    public void setId(String id) {
+        this.id = id;
     }
 
     // 직렬화할 때 사용
     @JsonGetter("id")
-    public String getLogin() {
-        return login;
+    public String getId() {
+        return id;
     }
 
     @JsonSetter("name")
@@ -46,12 +46,12 @@ public class GithubProfile {
     }
 
     @JsonSetter("avatar_url")
-    public void setAvatarUrl(String avatarUrl) {
-        this.avatarUrl = avatarUrl;
+    public void setImgUrl(String imgUrl) {
+        this.imgUrl = imgUrl;
     }
 
     @JsonGetter("imgUrl")
-    public String getAvatarUrl() {
-        return avatarUrl;
+    public String getImgUrl() {
+        return imgUrl;
     }
 }

--- a/be/issue-tracker/src/main/java/com/issuetracker/oauth/dto/OAuthInfo.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/oauth/dto/OAuthInfo.java
@@ -1,0 +1,14 @@
+package com.issuetracker.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class OAuthInfo {
+    @JsonProperty("access_token")
+    private String accessToken;
+}

--- a/be/issue-tracker/src/main/java/com/issuetracker/oauth/service/GithubLoginService.java
+++ b/be/issue-tracker/src/main/java/com/issuetracker/oauth/service/GithubLoginService.java
@@ -1,0 +1,65 @@
+package com.issuetracker.oauth.service;
+
+import com.issuetracker.oauth.dto.AccessTokenRequest;
+import com.issuetracker.oauth.dto.GithubProfile;
+import com.issuetracker.oauth.dto.OAuthInfo;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GithubLoginService {
+    private final WebClient webClient;
+
+    @Value("${oauth.github.client.id}")
+    private String clientId;
+    @Value("${oauth.github.client.secret}")
+    private String clientSecret;
+    @Value("${oauth.github.redirect.uri}")
+    private String redirectUri;
+
+    /**
+     * Access token을 요청한다.
+     */
+    public String getAccessToken(String code) {
+        OAuthInfo oAuthInfo = webClient.post()
+                .uri("https://github.com/login/oauth/access_token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(getAccessTokenRequest(code))
+                .accept(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .bodyToMono(OAuthInfo.class)
+                .block(); // 비동기 결과를 동기적으로 대기
+
+        return Objects.requireNonNull(oAuthInfo).getAccessToken();
+    }
+
+    /**
+     * 사용자 정보를 요청한다.
+     */
+    public GithubProfile getUserInfo(String accessToken) {
+        return webClient.get()
+                .uri("https://api.github.com/user")
+                .header("Authorization", "token " + accessToken)
+                .retrieve()
+                .bodyToMono(GithubProfile.class)
+                .doOnSuccess(profile -> log.info("Github 로그인한 사용자 정보 가져오기 성공 - {}", profile))
+                .doOnError(error -> log.error("Github 로그인한 사용자 정보 가져오기 실패 - {}", error.getMessage()))
+                .block();
+    }
+
+    private AccessTokenRequest getAccessTokenRequest(String code) {
+        return AccessTokenRequest.builder()
+                .client_id(clientId)
+                .client_secret(clientSecret)
+                .code(code)
+                .redirect_uri(redirectUri)
+                .build();
+    }
+}

--- a/be/issue-tracker/src/test/java/com/issuetracker/issue/service/IssueQueryServiceTest.java
+++ b/be/issue-tracker/src/test/java/com/issuetracker/issue/service/IssueQueryServiceTest.java
@@ -35,7 +35,7 @@ public class IssueQueryServiceTest {
 
         IssueCountDto issueCountDto = issueQueryService.countIssues();
 
-        assertThat(issueCountDto.getOpenedIssueCount()).isEqualTo(openedIssueCount);
-        assertThat(issueCountDto.getClosedIssueCount()).isEqualTo(closedIssueCount);
+        assertThat(issueCountDto.getOpenedCount()).isEqualTo(openedIssueCount);
+        assertThat(issueCountDto.getClosedCount()).isEqualTo(closedIssueCount);
     }
 }

--- a/be/issue-tracker/src/test/java/com/issuetracker/member/controller/MemberControllerTest.java
+++ b/be/issue-tracker/src/test/java/com/issuetracker/member/controller/MemberControllerTest.java
@@ -37,7 +37,7 @@ class MemberControllerTest {
         MemberCreateDto memberCreateDto = new MemberCreateDto("sangchu", "123", "상추", "sangchu@gmail.com");
         Member member = new Member("sangchu", "123", "상추", "sangchu@gmail.com", null);
         // Mock 서비스 레이어
-        when(memberService.create(ArgumentMatchers.any(MemberCreateDto.class))).thenReturn(member);
+        when(memberService.create(ArgumentMatchers.any(Member.class))).thenReturn(member);
 
         // MockMvc 요청 및 응답 검증
         String requestBody = objectMapper.writeValueAsString(memberCreateDto);

--- a/be/issue-tracker/src/test/java/com/issuetracker/member/service/MemberServiceTest.java
+++ b/be/issue-tracker/src/test/java/com/issuetracker/member/service/MemberServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.issuetracker.member.dto.MemberCreateDto;
 import com.issuetracker.member.entity.Member;
 import com.issuetracker.member.repository.MemberRepository;
+import com.issuetracker.member.util.MemberMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,7 @@ class MemberServiceTest {
         when(memberRepository.insert(any(Member.class))).thenReturn(expectedMember);
 
         // when
-        Member actualMember = memberService.create(memberCreateDto);
+        Member actualMember = memberService.create(MemberMapper.toMember(memberCreateDto));
 
         // then
         assertThat(actualMember).isNotNull()


### PR DESCRIPTION
### 4주동안 감사했습니다 우디 😊 👍🏻
배포된 저희의 사이트입니다 ☺️ 👉🏻 [이슈트래커](https://issue-tracker.site/)
 
<br>

## ✅ 구현 내용
- 깃허브 로그인
- 라벨 수정/이슈 필터링 카운트 기능 수정
- nginx로 http ➡️ https 포워딩 적용
- 프론트, 서버 모두 배포하여 도메인 적용 (https)

<br>

(저번주 PR에 JWT, Redis를 적용했는데 PR 메시지에는 적지 못하여 혹시 못보셨을까봐 다시 적어봅니다..!)
- JWT 구현
- Redis 적용

<br><br>

## 🤔 고민과 🙋🏻 질문
* 이번에 배포를 하면서 인프라때문에 고생을 했는데 🥲, 실무에서는 백엔드 개발자가 인프라 관련 지식을 얼마나 알고있어야 하는지 궁금합니다!
* Oauth Github login을 구현하면서 궁금했던 점인데, Oauth 자원 서버의 API로는 비밀번호를 제공하지 않는것으로 알고있는데 이런 경우 실무에서는 비밀번호 처리를 어떻게 하는지 궁금합니다. 저희는 멤버 DB에 저장하기 위해 Github login을 한 사용자는 비밀번호를 UUID로 생성하여 저장했습니다. 이 밖에도 Oauth로 로그인하는 사용자를 일반 회원가입 한 사용자와 구분하여 DB로 관리하는지 처리 과정이 궁금합니다. 

<br><br>